### PR TITLE
[Accton][as4630-54pe] Modify the versions showed by onlpdump -x

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
@@ -229,3 +229,25 @@ int psu_serial_number_get(int id, char *serial, int serial_len)
     return ONLP_STATUS_OK;
 }
 
+int get_i2c_bus_offset(int *bus_offset)
+{
+    int len = 0;
+    char *i2c_bus_0_name = NULL;
+
+    len = onlp_file_read_str(&i2c_bus_0_name, "/sys/bus/i2c/devices/i2c-0/name");
+
+    if(i2c_bus_0_name == NULL || len <= 0){
+        AIM_LOG_ERROR("Unable to read the name sysfs of i2c-0\r\n");
+        AIM_FREE_IF_PTR(i2c_bus_0_name);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    *bus_offset = 0;
+    if(!strncmp(i2c_bus_0_name, "SMBus iSMT", strlen("SMBus iSMT"))){
+        *bus_offset = -1;
+    }
+
+    AIM_FREE_IF_PTR(i2c_bus_0_name);
+    return ONLP_STATUS_OK;
+}
+

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
@@ -58,8 +58,7 @@
 #define CPLD_NODE_PATH	"/sys/bus/i2c/devices/i2c-3/3-0060/"
 #define FAN_NODE(node)	CPLD_NODE_PATH#node
 
-#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0057/eeprom"
-#define IDPROM_PATH_2 "/sys/bus/i2c/devices/1-0057/eeprom"
+#define IDPROM_PATH "/sys/bus/i2c/devices/%d-0057/eeprom"
 
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);
@@ -68,6 +67,8 @@ int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_l
 int psu_pmbus_info_get(int id, char *node, int *value);
 int psu_ym2651y_pmbus_info_get(int id, char *node, int *value);
 int psu_ym2651y_pmbus_info_set(int id, char *node, int value);
+
+int get_i2c_bus_offset(int *bus_offset);
 
 typedef enum psu_type {
     PSU_TYPE_UNKNOWN,
@@ -89,6 +90,15 @@ int psu_serial_number_get(int id, char *serial, int serial_len);
 #else
     #define DEBUG_PRINT(format, ...)  
 #endif
+
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 #endif  /* __PLATFORM_LIB_H__ */
 

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
@@ -37,12 +37,19 @@
 #include "x86_64_accton_as4630_54pe_log.h"
 
 
-#define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/3-0060/"
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 
-#define NUM_OF_CPLD                      3
+#define NUM_OF_CPLD_VER             4
 #define FAN_DUTY_CYCLE_MAX         (100)
 /* Note, all chassis fans share 1 single duty setting. 
  * Here use fan 1 to represent global fan duty value.*/
+
+static char* cpld_ver_path[NUM_OF_CPLD_VER] = {
+    "/sys/bus/i2c/devices/%d-0065/version",
+    "/sys/bus/i2c/devices/%d-0065/minor_version",
+    "/sys/bus/i2c/devices/3-0060/version",
+    "/sys/bus/i2c/devices/3-0060/minor_version",
+};
 
 const char*
 onlp_sysi_platform_get(void)
@@ -54,13 +61,16 @@ int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
 	uint8_t* rdata = aim_zmalloc(256);
+    
+    int bus_offset = 0;
+    char path[64];
 
-	if(onlp_file_read(rdata, 256, size, IDPROM_PATH_1) == ONLP_STATUS_OK) {
-		if(*size == 256) {
-			*data = rdata;
-			return ONLP_STATUS_OK;
-		}
-	} else if(onlp_file_read(rdata, 256, size, IDPROM_PATH_2) == ONLP_STATUS_OK) {
+    if(get_i2c_bus_offset(&bus_offset) != ONLP_STATUS_OK)
+        return ONLP_STATUS_E_INTERNAL;
+
+    snprintf(path, sizeof(path), IDPROM_PATH, 1+bus_offset);
+
+	if(onlp_file_read(rdata, 256, size, path) == ONLP_STATUS_OK) {
 		if(*size == 256) {
 			*data = rdata;
 			return ONLP_STATUS_OK;
@@ -106,20 +116,52 @@ onlp_sysi_oids_get(onlp_oid_t* table, int max)
 int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
-    int ver=0;
-	
-    if(onlp_file_read_int(&ver, "%s/version", PREFIX_PATH_ON_CPLD_DEV) < 0)
+    int i, v[NUM_OF_CPLD_VER] = {0};
+    int bus_offset = 0;
+    char path[64];
+    onlp_onie_info_t onie;
+    char *bios_ver = NULL;
+
+    if(get_i2c_bus_offset(&bus_offset) != ONLP_STATUS_OK) {
         return ONLP_STATUS_E_INTERNAL;
-		
-    pi->cpld_versions = aim_fstrdup("%d", ver);
-	
-    return 0;
+    }
+
+    for (i = 0; i < AIM_ARRAYSIZE(cpld_ver_path); i++) {
+        v[i] = 0;
+
+        if (i == 0 || i == 1) {
+            if(onlp_file_read_int(v+i, cpld_ver_path[i], 1+bus_offset) < 0) {
+                return ONLP_STATUS_E_INTERNAL;
+            }
+        } else if (i == 2 || i == 3) {
+            if(onlp_file_read_int(v+i, cpld_ver_path[i]) < 0) {
+                return ONLP_STATUS_E_INTERNAL;
+            }
+        }
+    }
+
+    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
+    
+    snprintf(path, sizeof(path), IDPROM_PATH, 1+bus_offset);
+    onlp_onie_decode_file(&onie, path);
+
+    pi->cpld_versions = aim_fstrdup("\r\n\t   CPU CPLD(0x65): %02X.%02X"
+                                    "\r\n\t   Main CPLD(0x60): %02X.%02X"
+                                    , v[0], v[1], v[2], v[3]);
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
+                                    bios_ver, onie.onie_version);
+
+    AIM_FREE_IF_PTR(bios_ver);
+
+    return ONLP_STATUS_OK;
 }
 
 void
 onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
     aim_free(pi->cpld_versions);
+    aim_free(pi->other_versions);
 }
 
 /* Temperature Policy

--- a/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/python/x86_64_accton_as4630_54pe_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/python/x86_64_accton_as4630_54pe_r0/__init__.py
@@ -32,7 +32,8 @@ class OnlPlatform_x86_64_accton_as4630_54pe_r0(OnlPlatformAccton,
             ('pca9548', 0x71, 2),
             ('pca9548', 0x70, 3),
             #initiate CPLD  
-            ('as4630_54pe_cpld', 0x60, 3)
+            ('as4630_54pe_cpld', 0x60, 3),
+            ('as4630_54pe_cpucpld', 0x65, 1+bus_offset)
             ])
         self.new_i2c_devices([
             # inititate LM77


### PR DESCRIPTION
1. modify the versions showed by onlpdump -x, including CPU CPLD, Main CPLD, BIOS, and ONIE.

2. remove unnecessary spaces and tabs in x86-64-accton-as4630-54pe-cpld.c