### PR TITLE
ONSBUSWI-2976: [AS9736-64D][Branch support_linux_6.1] sysi.c need to …

### DIFF
--- a/packages/platforms/accton/x86-64/as9736-64d/onlp/builds/x86_64_accton_as9736_64d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9736-64d/onlp/builds/x86_64_accton_as9736_64d/module/src/sysi.c
@@ -163,6 +163,7 @@ int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 void onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
 	aim_free(pi->cpld_versions);
+	aim_free(pi->other_versions);
 }
 
 /*


### PR DESCRIPTION
[AS9736-64D][Branch support_linux_6.1] sysi.c need to free the variable(cpld pi->other_versions) after memory allocate.