### PR TITLE
[Accton][as9926-24db] Add onlp_data_path_reset() to support chip rese…

### DIFF
--- a/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/fani.c
@@ -64,15 +64,6 @@ enum fan_id {
 	ONLP_FAN_MODE_INVALID,\
 }
 
-#define AIM_FREE_IF_PTR(p)		\
-	do 				\
-	{				\
-		if (p) { 		\
-			aim_free(p); 	\
-			p = NULL; 	\
-		} 			\
-	} while (0)
-
 /* Static fan information */
 onlp_fan_info_t finfo[] = {
 	{ }, /* Not used */

--- a/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/platform_lib.c
@@ -1,0 +1,66 @@
+/************************************************************
+ * <bsn.cl fy=2014 v=onl>
+ *
+ *           Copyright 2014 Big Switch Networks, Inc.
+ *           Copyright 2014 Accton Technology Corporation.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ * </bsn.cl>
+ ************************************************************
+ *
+ *
+ *
+ ***********************************************************/
+#include <unistd.h>
+#include <onlp/onlp.h>
+#include <onlplib/file.h>
+#include "platform_lib.h"
+
+#define WARM_RESET_FORMAT "/sys/devices/platform/as9926_24db_sys/reset_%s"
+
+/**
+ * @brief warm reset for mac
+ * @param unit_id The warm reset device unit id, should be 0
+ * @param reset_dev The warm reset device id, should be 1 ~ (WARM_RESET_MAX-1)
+ * @param ret return value.
+ */
+int onlp_data_path_reset(uint8_t unit_id, uint8_t reset_dev)
+{
+    int len = 0;
+    int ret = ONLP_STATUS_OK;
+    char *magic_num = NULL;
+    char *device_id[] = { NULL, "mac" };
+
+    if (unit_id != 0 || reset_dev >= WARM_RESET_MAX)
+        return ONLP_STATUS_E_PARAM;
+
+    if (reset_dev == 0)
+        return ONLP_STATUS_E_UNSUPPORTED;
+
+    /* Reset device */
+    len = onlp_file_read_str(&magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+    if (magic_num && len) {
+        ret = onlp_file_write_str(magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+        if (ret < 0) {
+            AIM_LOG_ERROR("Reset device-%d:(%s) failed.", reset_dev, device_id[reset_dev]);
+        }
+    }
+    else {
+        ret = ONLP_STATUS_E_INTERNAL;
+    }
+
+    AIM_FREE_IF_PTR(magic_num);
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/platform_lib.h
@@ -60,6 +60,11 @@ enum onlp_thermal_id
 	THERMAL_1_ON_PSU2,
 };
 
+enum reset_dev_type {
+	WARM_RESET_MAC = 1,
+	WARM_RESET_MAX
+};
+
 #define DEBUG_MODE 0
 
 #if (DEBUG_MODE == 1)

--- a/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as9926-24db/onlp/builds/x86_64_accton_as9926_24db/module/src/psui.c
@@ -35,14 +35,6 @@
 		}					\
 	} while(0)
 
-#define AIM_FREE_IF_PTR(p)				\
-	do {						\
-		if (p) {				\
-			aim_free(p); 			\
-			p = NULL;			\
-		} 					\
-	} while (0)
-
 int onlp_psui_init(void)
 {
 	return ONLP_STATUS_OK;


### PR DESCRIPTION
…t functionality

* Implements warm reset for MAC.
* @param unit_id: The warm reset device unit ID, should be 0.
* @param reset_dev: The warm reset device ID, should be 1 to (WARM_RESET_MAX-1).
* @param ret: Return value.