### PR TITLE
[Accton][as9716-32d]: Fixed fan_speed_rpm.

### DIFF
--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/x86-64-accton-as9716-32d-fan.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/x86-64-accton-as9716-32d-fan.c
@@ -198,7 +198,7 @@ static struct attribute *as9716_32d_fan_attributes[] = {
 
 #define FAN_DUTY_CYCLE_REG_MASK         0xF
 #define FAN_MAX_DUTY_CYCLE              100
-#define FAN_REG_VAL_TO_SPEED_RPM_STEP   100
+#define FAN_REG_VAL_TO_SPEED_RPM_STEP   200
 
 static int as9716_32d_fan_read_value(struct i2c_client *client, u8 reg)
 {


### PR DESCRIPTION
Front fan speed rpm value is [reg_val x 200] instead of using [reg_val x 100]