### PR TITLE
[Accton][as4630-54pe][as4630-54te] Add onlp_data_path_reset() to supp…

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-cpld.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-cpld.c
@@ -41,6 +41,7 @@
 #define FAN_DUTY_CYCLE_REG_MASK         0x1F
 #define FAN_MAX_DUTY_CYCLE              100
 #define FAN_REG_VAL_TO_SPEED_RPM_STEP   114 // R.P.M value = read value x3.79*60/2
+#define MAC_PCIE_RESET_DELAY            200 /* ms */
 
 /* CPLD */
 #define CPLD_MAJOR_VER_REG	(0x01)
@@ -112,6 +113,7 @@ enum as4630_54pe_cpld_sysfs_attributes {
 	CPLD_VERSION,
 	CPLD_MINOR_VERSION,
 	BIOS_FLASH_ID,
+	RESET_MAC,
 	ACCESS,
 	/* transceiver attributes */
 	TRANSCEIVER_RXLOS_ATTR_ID(49),
@@ -165,6 +167,10 @@ static ssize_t show_version(struct device *dev, struct device_attribute *da,
              char *buf);
 static ssize_t show_bios_flash_id(struct device *dev, struct device_attribute *da,
 		char *buf);
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+			char *buf);
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count);
 static int as4630_54pe_cpld_read_internal(struct i2c_client *client, u8 reg);
 static int as4630_54pe_cpld_write_internal(struct i2c_client *client, u8 reg, u8 value);
 
@@ -217,6 +223,7 @@ static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
 static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_version, NULL, CPLD_VERSION);
 static SENSOR_DEVICE_ATTR(minor_version, S_IRUGO, show_version, NULL, CPLD_MINOR_VERSION);
 static SENSOR_DEVICE_ATTR(bios_flash_id, S_IRUGO, show_bios_flash_id, NULL, BIOS_FLASH_ID);
+static SENSOR_DEVICE_ATTR(reset_mac, S_IRUGO | S_IWUSR, get_reset, set_reset, RESET_MAC);
 static SENSOR_DEVICE_ATTR(access, S_IWUSR, NULL, access, ACCESS);
 
 
@@ -237,6 +244,7 @@ DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR(1);
 static struct attribute *as4630_54pe_cpld_attributes[] = {
 	&sensor_dev_attr_version.dev_attr.attr,
 	&sensor_dev_attr_minor_version.dev_attr.attr,
+	&sensor_dev_attr_reset_mac.dev_attr.attr,
 	&sensor_dev_attr_access.dev_attr.attr,
 	DECLARE_SFP_TRANSCEIVER_ATTR(49),
 	DECLARE_SFP_TRANSCEIVER_ATTR(50),
@@ -580,6 +588,113 @@ static ssize_t show_bios_flash_id(struct device *dev, struct device_attribute *a
 	val = i2c_smbus_read_byte_data(client, 0x11);
 
 	return sprintf(buf, "%d\n", ( ((val >> 2) & 0x1) == 1 ) ? 1 : 2); /*(BIT2) 1: master, 2: slave*/
+}
+
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+			char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct as4630_54pe_cpld_data *data = i2c_get_clientdata(client);
+	
+	int status = 0, val = 0;
+	u8 reg = 0, mask_mac = 0x40, mask_pcie = 0x20, mask = 0;
+
+	switch (attr->index) {
+	case RESET_MAC:
+		reg  = 0xC;
+		mask = mask_mac | mask_pcie;
+		break;
+	default:
+		return 0;
+	}
+
+	mutex_lock(&data->update_lock);
+	status = as4630_54pe_cpld_read_internal(client, reg);
+
+	if (unlikely(status < 0)) {
+		goto exit;
+	}
+	mutex_unlock(&data->update_lock);
+
+	val = ((status & mask) == 0x0) ? 1 : 0;
+	return sprintf(buf, "%d\n", val);
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
+}
+
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+		       const char *buf, size_t count)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct as4630_54pe_cpld_data *data = i2c_get_clientdata(client);
+	long value;
+	int status;
+	u8 reg = 0, mask_mac, mask_pcie = 0;
+
+	status = kstrtol(buf, 10, &value);
+
+	if (status)
+		return status;
+
+	if (value != 1)
+		return -EINVAL;
+
+	switch (attr->index) {
+	case RESET_MAC:
+		reg  = 0xC;
+		mask_mac = 0x40;
+		mask_pcie = 0x20;
+
+		mutex_lock(&data->update_lock);
+
+		/* put mac & pcie to low */
+		status = as4630_54pe_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status &= ~(mask_mac | mask_pcie);
+		status = as4630_54pe_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		/* put mac to high */
+		status = as4630_54pe_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status |= mask_mac;
+		status = as4630_54pe_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		msleep(MAC_PCIE_RESET_DELAY);
+
+		/* put pcie to high */
+		status = as4630_54pe_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status |= mask_pcie;
+		status = as4630_54pe_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		mutex_unlock(&data->update_lock);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return count;
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
 }
 
 /* fan utility functions

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
@@ -272,3 +272,31 @@ int get_i2c_bus_offset(int *bus_offset)
     return ONLP_STATUS_OK;
 }
 
+/**
+ * @brief warm reset for mac
+ * @param unit_id The warm reset device unit id, should be 0
+ * @param reset_dev The warm reset device id, should be 1 ~ (WARM_RESET_MAX-1)
+ * @param ret return value.
+ */
+int onlp_data_path_reset(uint8_t unit_id, uint8_t reset_dev)
+{
+    int ret = ONLP_STATUS_OK;
+    char *device_id[] = { NULL, "mac" };
+    char buf[4] = "1";
+
+    if (unit_id != 0 || reset_dev >= WARM_RESET_MAX) {
+        return ONLP_STATUS_E_PARAM;
+    }
+
+    if (reset_dev == 0) {
+        return ONLP_STATUS_E_UNSUPPORTED;
+    }
+
+    /* Reset device */
+    ret = onlp_file_write_str(buf, WARM_RESET_FORMAT, device_id[reset_dev]);
+    if (ret < 0) {
+            AIM_LOG_ERROR("Reset device-%d:(%s) failed.", reset_dev, device_id[reset_dev]);
+    }
+
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
@@ -64,6 +64,8 @@
 #define IDPROM_PATH "/sys/bus/i2c/devices/%d-0057/eeprom"
 #define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 
+#define WARM_RESET_FORMAT "/sys/bus/i2c/devices/3-0060/reset_mac"
+
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);
@@ -84,6 +86,11 @@ typedef enum psu_type {
     PSU_TYPE_AC_F2B,
     PSU_TYPE_AC_B2F
 } psu_type_t;
+
+enum reset_dev_type {
+    WARM_RESET_MAC = 1,
+    WARM_RESET_MAX
+};
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
 int psu_serial_number_get(int id, char *serial, int serial_len);

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-cpld.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-cpld.c
@@ -41,6 +41,7 @@
 #define FAN_DUTY_CYCLE_REG_MASK 0x1F
 #define FAN_MAX_DUTY_CYCLE 100
 #define FAN_REG_VAL_TO_SPEED_RPM_STEP 114 // R.P.M = read value x3.79*60/2
+#define MAC_PCIE_RESET_DELAY            200 /* ms */
 
 static LIST_HEAD(cpld_client_list);
 static struct mutex list_lock;
@@ -104,6 +105,7 @@ enum as4630_54te_cpld_sysfs_attributes {
 	MAJOR_VERSION,
 	MINOR_VERSION,
 	BIOS_FLASH_ID,
+	RESET_MAC,
 	ACCESS,
 	/* transceiver attributes */
 	MODULE_PRESENT_ALL,
@@ -161,6 +163,10 @@ static ssize_t show_version(struct device *dev, struct device_attribute *da,
 			char *buf);
 static ssize_t show_bios_flash_id(struct device *dev, struct device_attribute *da,
             char *buf);
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+			char *buf);
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count);
 static int as4630_54te_cpld_read_internal(struct i2c_client *client,
 			u8 reg);
 static int as4630_54te_cpld_write_internal(struct i2c_client *client,
@@ -234,6 +240,7 @@ static SENSOR_DEVICE_ATTR(module_rx_los_all, S_IRUGO, show_rxlos_all, \
 static SENSOR_DEVICE_ATTR(major_version, S_IRUGO, show_version, NULL, MAJOR_VERSION);
 static SENSOR_DEVICE_ATTR(minor_version, S_IRUGO, show_version, NULL, MINOR_VERSION);
 static SENSOR_DEVICE_ATTR(bios_flash_id, S_IRUGO, show_bios_flash_id, NULL, BIOS_FLASH_ID);
+static SENSOR_DEVICE_ATTR(reset_mac, S_IRUGO | S_IWUSR, get_reset, set_reset, RESET_MAC);
 static SENSOR_DEVICE_ATTR(access, S_IWUSR, NULL, access, ACCESS);
 
 /* transceiver attributes */
@@ -253,6 +260,7 @@ DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR(1);
 static struct attribute *as4630_54te_cpld_attributes[] = {
 	&sensor_dev_attr_major_version.dev_attr.attr,
 	&sensor_dev_attr_minor_version.dev_attr.attr,
+	&sensor_dev_attr_reset_mac.dev_attr.attr,
 	&sensor_dev_attr_access.dev_attr.attr,
 	&sensor_dev_attr_module_present_all.dev_attr.attr,
 	&sensor_dev_attr_module_rx_los_all.dev_attr.attr,
@@ -612,6 +620,113 @@ static ssize_t show_bios_flash_id(struct device *dev, struct device_attribute *a
     val = i2c_smbus_read_byte_data(client, 0x11);
 
     return sprintf(buf, "%d\n", ( ((val >> 2) & 0x1) == 1 ) ? 1 : 2); /*(BIT2) 1: master, 2: slave*/
+}
+
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+			char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct as4630_54te_cpld_data *data = i2c_get_clientdata(client);
+	
+	int status = 0, val = 0;
+	u8 reg = 0, mask_mac = 0x40, mask_pcie = 0x20, mask = 0;
+
+	switch (attr->index) {
+	case RESET_MAC:
+		reg  = 0xC;
+		mask = mask_mac | mask_pcie;
+		break;
+	default:
+		return 0;
+	}
+
+	mutex_lock(&data->update_lock);
+	status = as4630_54te_cpld_read_internal(client, reg);
+
+	if (unlikely(status < 0)) {
+		goto exit;
+	}
+	mutex_unlock(&data->update_lock);
+
+	val = ((status & mask) == 0x0) ? 1 : 0;
+	return sprintf(buf, "%d\n", val);
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
+}
+
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+		       const char *buf, size_t count)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct as4630_54te_cpld_data *data = i2c_get_clientdata(client);
+	long value;
+	int status;
+	u8 reg = 0, mask_mac, mask_pcie = 0;
+
+	status = kstrtol(buf, 10, &value);
+
+	if (status)
+		return status;
+
+	if (value != 1)
+		return -EINVAL;
+
+	switch (attr->index) {
+	case RESET_MAC:
+		reg  = 0xC;
+		mask_mac = 0x40;
+		mask_pcie = 0x20;
+
+		mutex_lock(&data->update_lock);
+
+		/* put mac & pcie to low */
+		status = as4630_54te_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status &= ~(mask_mac | mask_pcie);
+		status = as4630_54te_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		/* put mac to high */
+		status = as4630_54te_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status |= mask_mac;
+		status = as4630_54te_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		msleep(MAC_PCIE_RESET_DELAY);
+
+		/* put pcie to high */
+		status = as4630_54te_cpld_read_internal(client, reg);
+		if (unlikely(status < 0))
+			goto exit;
+
+		status |= mask_pcie;
+		status = as4630_54te_cpld_write_internal(client, reg, status);
+		if (unlikely(status < 0))
+			goto exit;
+
+		mutex_unlock(&data->update_lock);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return count;
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
 }
 
 /* fan utility functions

--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
@@ -102,3 +102,32 @@ int get_i2c_bus_offset(int *bus_offset)
     AIM_FREE_IF_PTR(i2c_bus_0_name);
     return ONLP_STATUS_OK;
 }
+
+/**
+ * @brief warm reset for mac
+ * @param unit_id The warm reset device unit id, should be 0
+ * @param reset_dev The warm reset device id, should be 1 ~ (WARM_RESET_MAX-1)
+ * @param ret return value.
+ */
+int onlp_data_path_reset(uint8_t unit_id, uint8_t reset_dev)
+{
+    int ret = ONLP_STATUS_OK;
+    char *device_id[] = { NULL, "mac" };
+    char buf[4] = "1";
+
+    if (unit_id != 0 || reset_dev >= WARM_RESET_MAX) {
+        return ONLP_STATUS_E_PARAM;
+    }
+
+    if (reset_dev == 0) {
+        return ONLP_STATUS_E_UNSUPPORTED;
+    }
+
+    /* Reset device */
+    ret = onlp_file_write_str(buf, WARM_RESET_FORMAT, device_id[reset_dev]);
+    if (ret < 0) {
+            AIM_LOG_ERROR("Reset device-%d:(%s) failed.", reset_dev, device_id[reset_dev]);
+    }
+
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
@@ -59,6 +59,8 @@
 #define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0057/eeprom"
 #define IDPROM_PATH_2 "/sys/bus/i2c/devices/1-0057/eeprom"
 
+#define WARM_RESET_FORMAT "/sys/bus/i2c/devices/3-0060/reset_mac"
+
 int psu_pmbus_info_get(int id, char *node, int *value);
 int psu_status_info_get(int id, char *node, int *value);
 int get_i2c_bus_offset(int *bus_offset);
@@ -71,6 +73,11 @@ typedef enum psu_type {
     PSU_TYPE_UPD1501SA_1190G_F2B,
     PSU_TYPE_UPD1501SA_1290G_B2F
 } psu_type_t;
+
+enum reset_dev_type {
+    WARM_RESET_MAC = 1,
+    WARM_RESET_MAX
+};
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
 int get_psu_eeprom_str(int id, char *data_buf, int data_len, char *data_name);


### PR DESCRIPTION
…ort chip reset functionality

* Implements warm reset for MAC.
* @param unit_id: The warm reset device unit ID, should be 0.
* @param reset_dev: The warm reset device ID, should be 1 to (WARM_RESET_MAX-1).
* @param ret: Return value.