### PR TITLE
[Accton][as9817-64o][as9817-64d] Add onlp_data_path_reset() to suppor…

### DIFF
--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/accton_ipmi_intf.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/accton_ipmi_intf.c
@@ -24,7 +24,7 @@
 #define ACCTON_IPMI_NETFN 0x34
 #define IPMI_TIMEOUT (5 * HZ)
 #define IPMI_ERR_RETRY_TIMES 1
-#define RAW_CMD_BUF_SIZE 32
+#define RAW_CMD_BUF_SIZE 40
 
 static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data);
 

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
@@ -42,6 +42,8 @@
 #define IPMI_GET_FAN_CONTROLLER_CMD 0x66
 #define IPMI_SET_FAN_CONTROLLER_CMD 0x67
 #define IPMI_SEND_THERMAL_DATA_CMD 0x13
+#define IPMI_RESET_CMD 0x65
+#define IPMI_RESET_CMD_LENGTH 6
 
 static int as9817_64_sys_probe(struct platform_device *pdev);
 static int as9817_64_sys_remove(struct platform_device *pdev);
@@ -55,6 +57,10 @@ static ssize_t set_bmc_fan_controller(struct device *dev, struct device_attribut
             const char *buf, size_t count);
 static ssize_t set_bmc_thermal_data(struct device *dev, struct device_attribute *da,
             const char *buf, size_t count);
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+            char *buf);
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+            const char *buf, size_t count);
 
 struct as9817_64_sys_data {
     struct platform_device *pdev;
@@ -65,6 +71,8 @@ struct as9817_64_sys_data {
     unsigned char ipmi_resp_cpld[2];
     unsigned char ipmi_resp_fan_controller[1];
     unsigned char ipmi_tx_data[3];
+    unsigned char ipmi_resp_rst[2];
+    unsigned char ipmi_tx_data_rst[IPMI_RESET_CMD_LENGTH];
 };
 
 struct as9817_64_sys_data *data = NULL;
@@ -82,7 +90,8 @@ enum as9817_64_sys_sysfs_attrs {
     FPGA_VER, /* FPGA version */
     OTP_PROTECT,
     FAN_CONTROLLER,
-    THERMAL_DATA
+    THERMAL_DATA,
+    RESET_MAC
 };
 
 static SENSOR_DEVICE_ATTR(fpga_version, S_IRUGO, show_version, NULL, FPGA_VER);
@@ -91,12 +100,15 @@ static SENSOR_DEVICE_ATTR(bmc_fan_controller, S_IRUGO|S_IWUSR,
                           get_bmc_fan_controller, set_bmc_fan_controller, 
                           FAN_CONTROLLER);
 static SENSOR_DEVICE_ATTR(bmc_thermal_data, S_IWUSR, NULL, set_bmc_thermal_data, THERMAL_DATA);
+static SENSOR_DEVICE_ATTR(reset_mac, S_IWUSR | S_IRUGO, get_reset, \
+                          set_reset, RESET_MAC);
 
 static struct attribute *as9817_64_sys_attributes[] = {
     &sensor_dev_attr_fpga_version.dev_attr.attr,
     &sensor_dev_attr_otp_protect.dev_attr.attr,
     &sensor_dev_attr_bmc_fan_controller.dev_attr.attr,
     &sensor_dev_attr_bmc_thermal_data.dev_attr.attr,
+    &sensor_dev_attr_reset_mac.dev_attr.attr,
     NULL
 };
 
@@ -313,6 +325,72 @@ static ssize_t set_bmc_thermal_data(struct device *dev, struct device_attribute 
 
     if (unlikely(data->ipmi.rx_result != 0)) {
         status = -EINVAL;
+        goto exit;
+    }
+
+    status = count;
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return status;
+}
+
+static ssize_t get_reset(struct device *dev, struct device_attribute *da,
+                         char *buf)
+{
+    int status = 0;
+
+    mutex_lock(&data->update_lock);
+    status = ipmi_send_message(&data->ipmi, IPMI_RESET_CMD, NULL, 0,
+                       data->ipmi_resp_rst, sizeof(data->ipmi_resp_rst));
+    if (unlikely(status != 0))
+        goto exit;
+
+    if (unlikely(data->ipmi.rx_result != 0)) {
+        status = -EIO;
+        goto exit;
+    }
+
+    mutex_unlock(&data->update_lock);
+    return sprintf(buf, "0x%x 0x%x", data->ipmi_resp_rst[0], data->ipmi_resp_rst[1]);
+
+exit:
+    mutex_unlock(&data->update_lock);
+    return status;
+}
+
+static ssize_t set_reset(struct device *dev, struct device_attribute *da,
+                         const char *buf, size_t count)
+{
+    u32 magic[2];
+    int status;
+
+    if (sscanf(buf, "0x%x 0x%x", &magic[0], &magic[1]) != 2)
+        return -EINVAL;
+
+    if (magic[0] > 0xFF || magic[1] > 0xFF)
+        return -EINVAL;
+
+    mutex_lock(&data->update_lock);
+
+    /* Send IPMI write command */
+    
+    data->ipmi_tx_data_rst[0] = 0;
+    data->ipmi_tx_data_rst[1] = 0;
+    data->ipmi_tx_data_rst[2] = 1;
+    data->ipmi_tx_data_rst[3] = 1;
+    data->ipmi_tx_data_rst[4] = magic[0];
+    data->ipmi_tx_data_rst[5] = magic[1];
+
+    status = ipmi_send_message(&data->ipmi, IPMI_RESET_CMD,
+                   data->ipmi_tx_data_rst,
+                   sizeof(data->ipmi_tx_data_rst), NULL, 0);
+
+    if (unlikely(status != 0))
+        goto exit;
+
+    if (unlikely(data->ipmi.rx_result != 0)) {
+        status = -EIO;
         goto exit;
     }
 

--- a/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/platform_lib.c
@@ -175,3 +175,38 @@ int get_bmc_version(int *ver)
 
     return ONLP_STATUS_OK;
 }
+
+/**
+ * @brief warm reset for mac
+ * @param unit_id The warm reset device unit id, should be 0
+ * @param reset_dev The warm reset device id, should be 1 ~ (WARM_RESET_MAX-1)
+ * @param ret return value.
+ */
+int onlp_data_path_reset(uint8_t unit_id, uint8_t reset_dev)
+{
+    int len = 0;
+    int ret = ONLP_STATUS_OK;
+    char *magic_num = NULL;
+    char *device_id[] = { NULL, "mac" };
+
+    if (unit_id != 0 || reset_dev >= WARM_RESET_MAX)
+        return ONLP_STATUS_E_PARAM;
+
+    if (reset_dev == 0)
+        return ONLP_STATUS_E_UNSUPPORTED;
+
+    /* Reset device */
+    len = onlp_file_read_str(&magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+    if (magic_num && len) {
+        ret = onlp_file_write_str(magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+        if (ret < 0) {
+            AIM_LOG_ERROR("Reset device-%d:(%s) failed.", reset_dev, device_id[reset_dev]);
+        }
+    }
+    else {
+        ret = ONLP_STATUS_E_INTERNAL;
+    }
+
+    AIM_FREE_IF_PTR(magic_num);
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/platform_lib.h
@@ -54,6 +54,7 @@
 #define FGPA_MAC_MAX_TEMP_PATH "/sys/devices/platform/as9817_64_fpga/mac_max_temp"
 #define BMC_VER1_PATH  "/sys/devices/platform/ipmi_bmc.0/firmware_revision"
 #define BMC_VER2_PATH  "/sys/devices/platform/ipmi_bmc.0/aux_firmware_revision"
+#define WARM_RESET_FORMAT "/sys/devices/platform/as9817_64_sys/reset_%s"
 
 enum onlp_thermal_id {
     THERMAL_RESERVED = 0,
@@ -95,6 +96,11 @@ typedef enum as9817_64_platform_id {
     AS9817_64D,
     PID_UNKNOWN
 } as9817_64_platform_id_t;
+
+enum reset_dev_type {
+    WARM_RESET_MAC = 1,
+    WARM_RESET_MAX
+};
 
 enum onlp_fan_dir onlp_get_fan_dir(int fid);
 int onlp_get_psu_hwmon_idx(int pid);


### PR DESCRIPTION
…t chip reset functionality

* Implements warm reset for MAC.
* @param unit_id: The warm reset device unit ID, should be 0.
* @param reset_dev: The warm reset device ID, should be 1 to (WARM_RESET_MAX-1).
* @param ret: Return value.