### PR TITLE
[Accton][as9716-32d] Show MFU ver with onlpdump -x

### DIFF
--- a/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
@@ -65,6 +65,9 @@
 #define IDPROM_PATH_1 "/sys/class/i2c-adapter/i2c-0/0-0057/eeprom"
 #define IDPROM_PATH_2 "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 #define WARM_RESET_FORMAT "/sys/bus/i2c/devices/19-0060/reset_mac"
 
 int onlp_file_write_integer(char *filename, int value);
@@ -98,7 +101,7 @@ int psu_serial_number_get(int id, char *serial, int serial_len, char* model_name
 #if (DEBUG_MODE == 1)
     #define DEBUG_PRINT(format, ...)   printf(format, __VA_ARGS__)
 #else
-    #define DEBUG_PRINT(format, ...)  
+    #define DEBUG_PRINT(format, ...)
 #endif
 
 #define AIM_FREE_IF_PTR(p) \

--- a/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/sysi.c
@@ -37,7 +37,6 @@
 #include "x86_64_accton_as9716_32d_int.h"
 #include "x86_64_accton_as9716_32d_log.h"
 
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 #define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/"
 #define NUM_OF_CPLD                   5
@@ -62,9 +61,9 @@ onlp_sysi_platform_get(void)
 
 int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
-{    
+{
     uint8_t* rdata = aim_zmalloc(256);
-		
+
     /*New board eeprom i2c-addr is 0x57. Old board's eeprom i2c-addr is 0x56*/		
     if(onlp_file_read(rdata, 256, size, IDPROM_PATH_1) == ONLP_STATUS_OK) /*0x57*/
     {
@@ -130,9 +129,10 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   rv;
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
     char *paths[] = {IDPROM_PATH_2, IDPROM_PATH_1};
-
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
 
     for (i = 0 ; i < AIM_ARRAYSIZE(paths); i++ ){
         rv = onlp_onie_decode_file(&onie, paths[i]);
@@ -140,7 +140,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
         if(rv >= 0)
             break;
     }
-	
+
     for (i = 0; i < NUM_OF_CPLD; i++) {
         v[i] = 0;
 
@@ -154,12 +154,21 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   Main CPLD 3(0x62): %02X\r\n",
                                     v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
-	
+    AIM_FREE_IF_PTR(mfu_ver);
+
     return 0;
 }
 
@@ -170,8 +179,8 @@ onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
     aim_free(pi->other_versions);
 }
 
-/*Read fanN_direction=1: The air flow of Fan6 is ¡§AFI-Back to Front¡¨
- *                    0: The air flow of Fan6 is ¡§AFO-Front to back¡¨
+/*Read fanN_direction=1: The air flow of Fan6 is ï¿½ï¿½AFI-Back to Frontï¿½ï¿½
+ *                    0: The air flow of Fan6 is ï¿½ï¿½AFO-Front to backï¿½ï¿½
  */
 /*
  Thermal policy:
@@ -328,7 +337,7 @@ typedef struct fan_ctrl_policy {
    int pwm;
    int state;
 } fan_ctrl_policy_t;
-   
+
 /*For AFI. 2 state. LEVEL_FAN_MID(75%), LEVEL_FAN_MAX(100%)
   For AFO. 3 state. LEVEL_FAN_MIN(50%), LEVEL_FAN_MID(75%), LEVEL_FAN_MAX(100%)
  */
@@ -348,14 +357,14 @@ fan_ctrl_policy_t  fan_thermal_policy_f2b[] = { /*AFO*/
 {50,  0x7, LEVEL_FAN_MIN},
 {75,  0xb, LEVEL_FAN_MID},
 {100, 0xf, LEVEL_FAN_MAX},
-    
+
 };
 
 fan_ctrl_policy_t  fan_thermal_policy_b2f[] = { /*AFI*/
 {75,  0xb, LEVEL_FAN_MID},
 {100, 0xf, LEVEL_FAN_MAX}
 };
-    
+
 void onlp_sysi_shutdown(void)
 {
     char cmd_str[64];
@@ -363,7 +372,7 @@ void onlp_sysi_shutdown(void)
     snprintf(cmd_str, 63, "i2cset -y -f 19 0x60 0x60 0x10");
     system(cmd_str); 
 }
-    
+
 int onlp_sysi_get_duty_cycle_by_fan_state(int state, int direction)
 {
     int i;
@@ -387,9 +396,8 @@ int onlp_sysi_get_duty_cycle_by_fan_state(int state, int direction)
             }
         }
     }
-    return 0;     
-   
-}    
+    return 0;
+}
 /*
  * If only one PSU insert , and watt >800w. Must let DUT fan pwm >= 75% in AFO.
  *  Because the psu temp is high.
@@ -405,7 +413,7 @@ int onlp_sysi_check_psu_loading(void)
     int psu_p_out[2]={0, 0};
     int id=1;
     int check_psu_watt=0;
-    
+
     for (id=1; id<=2; id++)
     {
         if (psu_status_info_get(id, "psu_power_good", &psu_power_good[id-1]) != 0) {
@@ -442,8 +450,7 @@ int onlp_sysi_check_psu_loading(void)
     }
     else
         return 0;
-    
-    
+
     return 0;
     
 }
@@ -451,7 +458,7 @@ int onlp_sysi_check_psu_loading(void)
 #define FAN_SPEED_CTRL_PATH "/sys/bus/i2c/devices/17-0066/fan_duty_cycle_percentage"
 #define FAN_DIRECTION_PATH "/sys/bus/i2c/devices/17-0066/fan1_direction"
 #define CHECK_TIMES 3
-    
+
 static int fan_state=LEVEL_FAN_INIT;
 static int fan_fail = 0;
 
@@ -470,13 +477,13 @@ int onlp_sysi_platform_manage_fans(void)
     int psu_full_load=0;
     onlp_thermal_info_t thermal[8];
     char  buf[10] = {0};
-    
+
     /* Get fan direction
      */
     if (onlp_file_read_int(&direction_val, FAN_DIRECTION_PATH) < 0) {
         AIM_LOG_ERROR("Unable to read status from file (%s)\r\n", FAN_DIRECTION_PATH); 
     }
-    
+
     if(fan_state==LEVEL_FAN_INIT)
     {
         fan_state=LEVEL_FAN_MAX; /*This is default state*/
@@ -488,7 +495,7 @@ int onlp_sysi_platform_manage_fans(void)
         return ONLP_STATUS_OK;    
     else
         count_check=0;
-        
+
     /* Get current temperature
      */
     for (i=2; i <5; i++)
@@ -500,7 +507,7 @@ int onlp_sysi_platform_manage_fans(void)
             return ONLP_STATUS_E_INTERNAL;
        }
         k++; 
-    }    
+    }
     for (i=6; i <=8; i++)
     {
         if (onlp_thermali_info_get(ONLP_THERMAL_ID_CREATE(i), &thermal[k]) != ONLP_STATUS_OK  )
@@ -559,7 +566,7 @@ int onlp_sysi_platform_manage_fans(void)
                 if (thermal[i].mcelsius <= afi_thermal_spec.max_to_mid_temp[i])
                 {
                     max_to_mid++;
-                }            
+                }
             }
         }
         if(max_to_mid==CHASSIS_THERMAL_COUNT && fan_state==LEVEL_FAN_MAX)
@@ -602,7 +609,7 @@ int onlp_sysi_platform_manage_fans(void)
                 }
             }
             else
-            {                
+            {
                 if (thermal[i].mcelsius <= afo_thermal_spec.max_to_mid_temp[i])
                 {
                     max_to_mid++;
@@ -651,8 +658,7 @@ int onlp_sysi_platform_manage_fans(void)
             {
                 current_state=LEVEL_FAN_MID;
             }
-           
-             
+
             if (fan_alarm_state)
             {
                 fan_alarm_state=0;
@@ -713,7 +719,7 @@ int onlp_sysi_platform_manage_fans(void)
             }
             break;
         }
-        fan_fail=0;           	    
+        fan_fail=0;
     }
     if(current_state!=ori_state)
     {
@@ -729,13 +735,13 @@ int onlp_sysi_platform_manage_fans(void)
             onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_CYCLE_MAX);
         }
     }
-  
+
     return 0;
-}   
+}
 
 int
 onlp_sysi_platform_manage_leds(void)
 {
     return ONLP_STATUS_E_UNSUPPORTED;
 }
-   
+

--- a/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
@@ -66,17 +66,31 @@ def config_sfp_retimer():
 
 def get_mfu_ver_file():
     cmd_list = [
-        'mkdir -p /mnt/onie-boot',
-        'mount -L ONIE-BOOT /mnt/onie-boot',
-        'cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp',
-        'umount /mnt/onie-boot'
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
     ]
 
     for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print "last_updated_MFU_version file does not exist !"
+                continue
+                
         process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.communicate()
+
         if process.returncode != 0:
-            print 'error! return code of cmd ' + cmd +': ', process.returncode
+            if "blkid" in cmd and process.returncode == 1:
+                print "ONIE-BOOT label does not exist !"
+            else:
+                print "'" + cmd + "'" + " runs with error return code:", process.returncode
+                
+                if "cp -a" in cmd:
+                    continue
+
             return False
 
     return True

--- a/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
@@ -64,6 +64,23 @@ def config_sfp_retimer():
 
     return True
 
+def get_mfu_ver_file():
+    cmd_list = [
+        'mkdir -p /mnt/onie-boot',
+        'mount -L ONIE-BOOT /mnt/onie-boot',
+        'cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp',
+        'umount /mnt/onie-boot'
+    ]
+
+    for cmd in cmd_list:
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+        if process.returncode != 0:
+            print 'error! return code of cmd ' + cmd +': ', process.returncode
+            return False
+
+    return True
+
 class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x25_6x100):
 
@@ -78,19 +95,19 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
             self.insmod("x86-64-accton-as9716-32d-%s.ko" % m)
 
         ########### initialize I2C bus 0 ###########
-        # initialize multiplexer (PCA9548)        
+        # initialize multiplexer (PCA9548)
         self.new_i2c_device('pca9548', 0x77, 0)
         # initiate multiplexer (PCA9548)
         self.new_i2c_devices(
             [
-                # initiate multiplexer (PCA9548)                
+                # initiate multiplexer (PCA9548)
                 ('pca9548', 0x72, 1),
-                ('pca9548', 0x76, 1),                
+                ('pca9548', 0x76, 1),
             ]
         )
         self.new_i2c_devices(
             [
-                # initiate multiplexer (PCA9548)                
+                # initiate multiplexer (PCA9548)
                 ('pca9548', 0x72, 2),
                 ('pca9548', 0x73, 2), 
                 ('pca9548', 0x74, 2),
@@ -101,7 +118,7 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
         self.new_i2c_devices([
             # initialize CPLD
              #initiate CPLD
-            ('as9716_32d_fpga', 0x60, 19),            
+            ('as9716_32d_fpga', 0x60, 19),
             ('as9716_32d_cpld1', 0x61, 20),
             ('as9716_32d_cpld2', 0x62, 21),
             ('as9716_32d_cpu_cpld', 0x65, 0),
@@ -111,7 +128,7 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
               # initiate chassis fan
             ('as9716_32d_fan', 0x66, 17),
 
-            # inititate LM75           
+            # inititate LM75
             ('lm75', 0x48, 18),
             ('lm75', 0x49, 18),
             ('lm75', 0x4a, 18),
@@ -140,9 +157,9 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
                 self.new_i2c_device('optoe1', 0x50, port+24)
             else:
                 self.new_i2c_device('optoe2', 0x50, port+24)
-            
+
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+24), shell=True)
-       
+
         #Dut to new board eeprom i2c-addr is 0x57, old board eeprom i2c-addr is 0x56. So need to check and set correct i2c-addr sysfs
         ret=eeprom_check()
         if ret==0:
@@ -152,4 +169,6 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
             self.new_i2c_device('24c02', 0x56, 0)
 
         config_sfp_retimer()
+        get_mfu_ver_file()
+
         return True


### PR DESCRIPTION
1. the last_updated_MFU_version file in ONIE partition is copied to ONL's /var/tmp/ on ONL boot

2. onlpdump -x reads /var/tmp/last_updated_MFU_version for MFU ver

3. remove unnecessary spaces and tabs in platform_lib.h, sysi.c, and __init__.py