### PR TITLE
support new DC PSU New PSU: YM-2401HCR,YM-2401HDR

### DIFF
--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/fani.c
@@ -167,7 +167,7 @@ _onlp_get_fan_direction_on_psu(void)
             continue;
         }
 
-        if (PSU_TYPE_AC_F2B == psu_type) {
+        if (PSU_TYPE_AC_F2B == psu_type || PSU_TYPE_DC_F2B == psu_type) {
             return ONLP_FAN_STATUS_F2B;
         }
         else {

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
@@ -101,6 +101,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
 
         AIM_FREE_IF_PTR(fd);
     }
+    else if (strncmp(mn, "YM-2401HCR", 10) == 0) {
+        ptype = PSU_TYPE_DC_F2B;
+    }
+    else if (strncmp(mn, "YM-2401HDR", 10) == 0) {
+        ptype = PSU_TYPE_DC_B2F;
+    }
     else if (strncmp(mn, "DPS400AB33A", PSU_MODEL_NAME_LEN) == 0) {
         ptype = PSU_TYPE_AC_F2B;
     }

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.h
@@ -69,11 +69,15 @@ enum onlp_thermal_id
 typedef enum psu_type {
     PSU_TYPE_UNKNOWN,
     PSU_TYPE_AC_F2B,
-    PSU_TYPE_AC_B2F
+    PSU_TYPE_AC_B2F,
+    PSU_TYPE_DC_F2B,
+    PSU_TYPE_DC_B2F
 } psu_type_t;
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
 int get_psu_serial_number(int id, char *serial, int serial_len);
+
+#define IS_DC_INPUT(psu_type) (PSU_TYPE_DC_F2B == psu_type || PSU_TYPE_DC_B2F == psu_type)
 
 #define DEBUG_MODE 0
 

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/psui.c
@@ -68,18 +68,18 @@ onlp_psui_init(void)
 }
 
 static int
-psu_ym1401_info_get(onlp_psu_info_t* info)
+psu_ym1401_info_get(onlp_psu_info_t* info, bool is_dc_input)
 {
     int val   = 0;
     int index = ONLP_OID_ID_GET(info->hdr.id);
     
     /* Set capability
      */
-    info->caps = ONLP_PSU_CAPS_AC;
+    info->caps = (is_dc_input)? ONLP_PSU_CAPS_DC48 : ONLP_PSU_CAPS_AC;
     
-	if (info->status & ONLP_PSU_STATUS_FAILED) {
-	    return ONLP_STATUS_OK;
-	}
+    if (info->status & ONLP_PSU_STATUS_FAILED) {
+        return ONLP_STATUS_OK;
+    }
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
@@ -162,7 +162,9 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     switch (psu_type) {
         case PSU_TYPE_AC_F2B:
         case PSU_TYPE_AC_B2F:
-            ret = psu_ym1401_info_get(info);
+        case PSU_TYPE_DC_F2B:
+        case PSU_TYPE_DC_B2F:
+            ret = psu_ym1401_info_get(info, IS_DC_INPUT(psu_type));
             break;
         case PSU_TYPE_UNKNOWN:  /* User insert a unknown PSU or unplugged.*/
             info->status |= ONLP_PSU_STATUS_UNPLUGGED;


### PR DESCRIPTION
Test log about this new PSU model.
```
   psu @ 2 = {
       Description: PSU-2
       Model:  YM-2401HCR
       SN:     SB000T701748000048
       Status: 0x00000001 [ PRESENT ]
       Caps:   0x00000154 [ DC48,VOUT,IOUT,POUT ]
       Vin:    0
       Vout:   12187
       Iin:    0
       Iout:   7187
       Pin:    0
       Pout:   81250
       fan @ 7 = {
           Description: PSU 2 - Fan 1
           Status: 0x00000009 [ PRESENT,F2B ]
           Caps:   0x00000038 [ SET_PERCENTAGE,GET_RPM,GET_PERCENTAGE ]
           RPM:    10896
           Per:    50
           Model:  NULL
           SN:     NULL
       }
       thermal @ 7 = {
           Description: PSU-2 Thermal Sensor 1
           Status: 0x00000001 [ PRESENT ]
           Caps:   0x0000000f [ GET_TEMPERATURE,GET_WARNING_THRESHOLD,GET_ERROR_THRESHOLD,GET_SHUTDOWN_THRESHOLD ]
           Temperature: 25000
           thresholds = {
               Warning: 45000
               Error: 55000
               Shutdown: 60000
           }
       }
   }
```