### PR TITLE
[AS9716-32D] Upgrade kernel to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as9716_32d/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9716-32d ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9716-32d ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as9716-32d

--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-cpld.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-cpld.c
@@ -735,9 +735,9 @@ exit:
 /*
  * I2C init/probing/exit functions
  */
-static int as9716_32d_cpld_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as9716_32d_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as9716_32d_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-fan.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-fan.c
@@ -435,8 +435,7 @@ static const struct hwmon_chip_info as9716_32d_fan_chip_info = {
     .info = as9716_32d_fan_info,
 };
 
-static int as9716_32d_fan_probe(struct i2c_client *client,
-                                const struct i2c_device_id *dev_id)
+static int as9716_32d_fan_probe(struct i2c_client *client)
 {
     struct as9716_32d_fan_data *data;
     int status;

--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-leds.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-leds.c
@@ -402,15 +402,13 @@ static int accton_as9716_32d_led_probe(struct platform_device *pdev)
     return ret;
 }
 
-static int accton_as9716_32d_led_remove(struct platform_device *pdev)
+static void accton_as9716_32d_led_remove(struct platform_device *pdev)
 {
     int i;
 
     for (i = 0; i < ARRAY_SIZE(accton_as9716_32d_leds); i++) {
         led_classdev_unregister(&accton_as9716_32d_leds[i]);
     }
-
-    return 0;
 }
 
 static struct platform_driver accton_as9716_32d_led_driver = {

--- a/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-psu.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/modules/builds/src/x86-64-accton-as9716-32d-psu.c
@@ -168,9 +168,9 @@ static const struct hwmon_chip_info as9716_32d_psu_chip_info = {
     .info = as9716_32d_psu_info,
 };
 
-static int as9716_32d_psu_probe(struct i2c_client *client,
-                                const struct i2c_device_id *dev_id)
+static int as9716_32d_psu_probe(struct i2c_client *client)
 {
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
     struct as9716_32d_psu_data *data;
     int status;
 

--- a/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
@@ -62,8 +62,8 @@
 #define FAN_NODE(node)	FAN_BOARD_PATH#node
 
 /*Old board's eeprom i2c-addr is 0x56, new board eeprom i2c-addr is 0x57*/
-#define IDPROM_PATH_1 "/sys/class/i2c-adapter/i2c-0/0-0057/eeprom"
-#define IDPROM_PATH_2 "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
+#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0057/eeprom"
+#define IDPROM_PATH_2 "/sys/bus/i2c/devices/0-0056/eeprom"
 
 #define WARM_RESET_FORMAT "/sys/bus/i2c/devices/19-0060/reset_mac"
 

--- a/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/sysi.c
@@ -128,7 +128,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int   i, v[NUM_OF_CPLD]={0};
     int   rv;
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
     char *paths[] = {IDPROM_PATH_2, IDPROM_PATH_1};
 

--- a/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/lib/x86-64-accton-as9716-32d-r0.yml
+++ b/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/lib/x86-64-accton-as9716-32d-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as9716-32d-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       nopat


### PR DESCRIPTION
- Update PKG.yml and builds/Makefile to target onl-kernel-6.12-lts-x86-64-all
- Update platform-config to use *kernel-6-12 anchor
- Adapt cpld/fan/psu probe signatures for Linux 6.12 i2c_driver.probe API 
(drop second param, use i2c_client_get_device_id where needed)
- Change led_remove return type from int to void for Linux 6.12 
platform_driver.remove API
- Update IDPROM path