### PR TITLE
[AS7712-32X] Upgrade kernel to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as7712-32x/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7712-32x ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7712-32x ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7712-32x/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7712-32x

--- a/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-cpld1.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-cpld1.c
@@ -584,9 +584,9 @@ static const struct hwmon_chip_info as7712_32x_cpld_chip_info = {
     .info = as7712_32x_cpld_info,
 };
 
-static int as7712_32x_cpld_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static int as7712_32x_cpld_probe(struct i2c_client *client)
 {
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
     int status;
     int ret = -ENODEV;
 	struct as7712_32x_cpld_data *data = NULL;

--- a/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-fan.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-fan.c
@@ -465,8 +465,7 @@ static const struct hwmon_chip_info as7712_32x_fan_chip_info = {
     .info = as7712_32x_fan_info,
 };
 
-static int as7712_32x_fan_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static int as7712_32x_fan_probe(struct i2c_client *client)
 {
     struct as7712_32x_fan_data *data;
     int status;

--- a/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-leds.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-leds.c
@@ -363,15 +363,13 @@ static int accton_as7712_32x_led_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int accton_as7712_32x_led_remove(struct platform_device *pdev)
+static void accton_as7712_32x_led_remove(struct platform_device *pdev)
 {
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(accton_as7712_32x_leds); i++) {
 		led_classdev_unregister(&accton_as7712_32x_leds[i]);
 	}
-
-	return 0;
 }
 
 static struct platform_driver accton_as7712_32x_led_driver = {

--- a/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-psu.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/modules/builds/src/x86-64-accton-as7712-32x-psu.c
@@ -185,9 +185,9 @@ static const struct hwmon_chip_info as7712_32x_psu_chip_info = {
     .info = as7712_32x_psu_info,
 };
 
-static int as7712_32x_psu_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static int as7712_32x_psu_probe(struct i2c_client *client)
 {
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
     struct as7712_32x_psu_data *data;
     int status;
 

--- a/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/platform_lib.h
@@ -48,8 +48,8 @@
 #define PSU1_AC_HWMON_NODE(node) PSU1_AC_HWMON_PREFIX#node
 #define PSU2_AC_HWMON_NODE(node) PSU2_AC_HWMON_PREFIX#node
 
-#define IDPROM_PATH_1 "/sys/class/i2c-adapter/i2c-0/0-0057/eeprom"
-#define IDPROM_PATH_2 "/sys/class/i2c-adapter/i2c-1/1-0057/eeprom"
+#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0057/eeprom"
+#define IDPROM_PATH_2 "/sys/bus/i2c/devices/1-0057/eeprom"
 
 #define WARM_RESET_FORMAT "/sys/bus/i2c/devices/4-0060/reset_mac"
 

--- a/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/sysi.c
@@ -87,7 +87,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   i, v[NUM_OF_CPLD]={0};
     char *bios_ver = NULL;
     char str[20]={0};
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
 
     /* BIOS version */
     onlp_file_read_str(&bios_ver, BIOS_VER_PATH);

--- a/packages/platforms/accton/x86-64/as7712-32x/platform-config/r0/src/lib/x86-64-accton-as7712-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7712-32x/platform-config/r0/src/lib/x86-64-accton-as7712-32x-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7712-32x-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       nopat


### PR DESCRIPTION
- Update PKG.yml and builds/Makefile to target onl-kernel-6.12-lts-x86-64-all
- Update platform-config to use *kernel-6-12 anchor
- Adapt cpld/fan/psu probe signatures for Linux 6.12 i2c_driver.probe API
      (drop second param, use i2c_client_get_device_id where needed)
- Change led_remove return type from int to void for Linux 6.12
      platform_driver.remove API
- Update IDPROM_PATH