### PR TITLE
[AS4630-54TE][AS4630-54PE] Upgrade kernel to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4630-54pe ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4630-54pe ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as4630-54pe

--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-cpld.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-cpld.c
@@ -855,9 +855,9 @@ static struct as4630_54pe_cpld_data *as4630_54pe_fan_update_device(struct device
 /*
  * I2C init/probing/exit functions
  */
-static int as4630_54pe_cpld_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as4630_54pe_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as4630_54pe_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-leds.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-leds.c
@@ -486,15 +486,13 @@ static int accton_as4630_54pe_led_probe(struct platform_device *pdev)
     return ret;
 }
 
-static int accton_as4630_54pe_led_remove(struct platform_device *pdev)
+static void accton_as4630_54pe_led_remove(struct platform_device *pdev)
 {
     int i;
 
     for (i = 0; i < ARRAY_SIZE(accton_as4630_54pe_leds); i++) {
         led_classdev_unregister(&accton_as4630_54pe_leds[i]);
     }
-
-    return 0;
 }
 
 static struct platform_driver accton_as4630_54pe_led_driver = {

--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-psu.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/src/x86-64-accton-as4630-54pe-psu.c
@@ -214,9 +214,9 @@ static int find_models_min_offset(void) {
     return min_offset;
 }
 
-static int as4630_54pe_psu_probe(struct i2c_client *client,
-                                const struct i2c_device_id *dev_id)
+static int as4630_54pe_psu_probe(struct i2c_client *client)
 {
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
     struct as4630_54pe_psu_data *data;
     int status;
 

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
@@ -118,7 +118,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int i, v[NUM_OF_CPLD_VER] = {0};
     int bus_offset = 0;
     char path[64];
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
 
     if(get_i2c_bus_offset(&bus_offset) != ONLP_STATUS_OK) {

--- a/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/lib/x86-64-accton-as4630-54pe-r0.yml
+++ b/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/lib/x86-64-accton-as4630-54pe-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as4630-54pe-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       nopat

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4630-54te ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4630-54te ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as4630-54te

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-cpld.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-cpld.c
@@ -898,9 +898,9 @@ static struct as4630_54te_cpld_data *as4630_54te_fan_update_device(
 /*
  * I2C init/probing/exit functions
  */
-static int as4630_54te_cpld_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as4630_54te_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as4630_54te_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-leds.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-leds.c
@@ -470,14 +470,12 @@ static int as4630_54te_led_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int as4630_54te_led_remove(struct platform_device *pdev)
+static void as4630_54te_led_remove(struct platform_device *pdev)
 {
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(as4630_54te_leds); i++)
 		led_classdev_unregister(&as4630_54te_leds[i]);
-
-	return 0;
 }
 
 static struct platform_driver as4630_54te_led_driver = {

--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-psu.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/src/x86-64-accton-as4630-54te-psu.c
@@ -224,9 +224,9 @@ static int find_models_min_offset(void) {
     return min_offset;
 }
 
-static int as4630_54te_psu_probe(struct i2c_client *client,
-				const struct i2c_device_id *dev_id)
+static int as4630_54te_psu_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	struct as4630_54te_psu_data *data;
 	int status;
 

--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
@@ -111,7 +111,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int i, v[NUM_OF_CPLD_VER] = {0};
     int bus_offset = 0;
     char path[64];
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
 
     get_i2c_bus_offset(&bus_offset);

--- a/packages/platforms/accton/x86-64/as4630-54te/platform-config/r0/src/lib/x86-64-accton-as4630-54te-r0.yml
+++ b/packages/platforms/accton/x86-64/as4630-54te/platform-config/r0/src/lib/x86-64-accton-as4630-54te-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as4630-54te-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
- Update PKG.yml and builds/Makefile to target onl-kernel-6.12-lts-x86-64-all
- Update platform-config to use *kernel-6-12 anchor
- Adapt cpld/psu probe signatures for Linux 6.12 i2c_driver.probe API
(drop second param, use i2c_client_get_device_id where needed)
- Change led_remove return type from int to void for Linux 6.12
platform_driver.remove API