### PR TITLE
[AS4625-54T] Upgrade kernel to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as4625-54t/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4625-54t ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as4625-54t ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as4625-54t/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as4625-54t

--- a/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-cpld.c
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-cpld.c
@@ -517,9 +517,9 @@ exit:
 /*
  * I2C init/probing/exit functions
  */
-static int as4625_cpld_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as4625_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as4625_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-fan.c
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-fan.c
@@ -381,11 +381,10 @@ exit_remove:
 	return status;
 }
 
-static int as4625_fan_remove(struct platform_device *pdev)
+static void as4625_fan_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&data->hwmon_dev->kobj, &as4625_fan_group);
 	hwmon_device_unregister(data->hwmon_dev);
-	return 0;
 }
 
 static struct platform_driver as4625_fan_driver = {

--- a/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-leds.c
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-leds.c
@@ -332,14 +332,12 @@ static int as4625_led_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int as4625_led_remove(struct platform_device *pdev)
+static void as4625_led_remove(struct platform_device *pdev)
 {
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(as4625_leds); i++)
 		led_classdev_unregister(&as4625_leds[i]);
-
-	return 0;
 }
 
 static struct platform_driver as4625_led_driver = {

--- a/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-psu.c
+++ b/packages/platforms/accton/x86-64/as4625-54t/modules/builds/src/x86-64-accton-as4625-54t-psu.c
@@ -190,9 +190,9 @@ static const struct attribute_group as4625_54t_psu_group = {
 	.attrs = as4625_54t_psu_attributes,
 };
 
-static int as4625_54t_psu_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as4625_54t_psu_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	struct as4625_54t_psu_data *data;
 	int status;
 

--- a/packages/platforms/accton/x86-64/as4625-54t/onlp/builds/x86_64_accton_as4625_54t/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as4625-54t/onlp/builds/x86_64_accton_as4625_54t/module/src/sysi.c
@@ -111,7 +111,7 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int ver_major = 0, ver_minor = 0, bus = 0;
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
     char prefix_path[64];
 

--- a/packages/platforms/accton/x86-64/as4625-54t/platform-config/r0/src/lib/x86-64-accton-as4625-54t-r0.yml
+++ b/packages/platforms/accton/x86-64/as4625-54t/platform-config/r0/src/lib/x86-64-accton-as4625-54t-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as4625-54t-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
- Update PKG.yml and builds/Makefile to target onl-kernel-6.12-lts-x86-64-all
- Update platform-config to use *kernel-6-12 anchor
- Adapt cpld/psu probe signatures for Linux 6.12 i2c_driver.probe API
(drop second param, use i2c_client_get_device_id where needed)
- Change fan/led remove return type from int to void for Linux 6.12
platform_driver.remove API