### PR TITLE
[Accton] Remove modprobe at24

### DIFF
--- a/packages/platforms/accton/x86-64/as4625-54t/platform-config/r0/src/python/x86_64_accton_as4625_54t_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as4625-54t/platform-config/r0/src/python/x86_64_accton_as4625_54t_r0/__init__.py
@@ -15,7 +15,6 @@ class OnlPlatform_x86_64_accton_as4625_54t_r0(OnlPlatformAccton,
     SYS_OBJECT_ID=".4625.54.1"
 
     def baseconfig(self):
-        os.system("modprobe at24")
         self.insmod('optoe')
         self.insmod('ym2651y')
 

--- a/packages/platforms/accton/x86-64/as7515-24x/platform-config/r0/src/python/x86_64_accton_as7515_24x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7515-24x/platform-config/r0/src/python/x86_64_accton_as7515_24x_r0/__init__.py
@@ -20,7 +20,6 @@ class OnlPlatform_x86_64_accton_as7515_24x_r0(OnlPlatformAccton,
 
     def baseconfig(self):
         self.modprobe('optoe')
-        self.modprobe('at24')
         self.modprobe('ym2651y')
 
         for m in [ 'fpga', 'cpld', 'fan', 'leds', 'mux', 'psu', 'sfp' ]:

--- a/packages/platforms/accton/x86-64/as9737-32db/platform-config/r0/src/python/x86_64_accton_as9737_32db_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9737-32db/platform-config/r0/src/python/x86_64_accton_as9737_32db_r0/__init__.py
@@ -91,7 +91,6 @@ class OnlPlatform_x86_64_accton_as9737_32db_r0(OnlPlatformAccton,
             return False
 
         self.modprobe('optoe')
-        self.modprobe('at24')
         self.insmod('accton_ipmi_intf')
 
         for m in [ 'i2c-ocores', 'fpga', 'mux', 'cpld', 'fan', 'psu', 'thermal', 'sys', 'leds' ]:

--- a/packages/platforms/accton/x86-64/as9737-32db/platform-config/r0/src/python/x86_64_accton_as9737_32db_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9737-32db/platform-config/r0/src/python/x86_64_accton_as9737_32db_r0/__init__.py
@@ -108,8 +108,6 @@ class OnlPlatform_x86_64_accton_as9737_32db_r0(OnlPlatformAccton,
                 ('as9737_32db_cpld2', 0x61, 36),
                 ('as9737_32db_cpld3', 0x62, 37),
 
-                # EEPROM
-                #('24c02', 0x56, 0),
                 ]
             )
 

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64d/platform-config/r0/src/python/x86_64_accton_as9817_64d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64d/platform-config/r0/src/python/x86_64_accton_as9817_64d_r0/__init__.py
@@ -89,7 +89,6 @@ class OnlPlatform_x86_64_accton_as9817_64d_r0(OnlPlatformAccton,
             return False
 
         self.modprobe('optoe')
-        self.modprobe('at24')
         self.modprobe('accton_ipmi_intf')
 
         for m in [ 'i2c-ocores', 'fpga', 'mux', 'fan', 'psu', 'thermal', 'sys', 'leds' ]:

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64o/platform-config/r0/src/python/x86_64_accton_as9817_64o_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64o/platform-config/r0/src/python/x86_64_accton_as9817_64o_r0/__init__.py
@@ -89,7 +89,6 @@ class OnlPlatform_x86_64_accton_as9817_64o_r0(OnlPlatformAccton,
             return False
 
         self.modprobe('optoe')
-        self.modprobe('at24')
         self.modprobe('accton_ipmi_intf')
 
         for m in [ 'i2c-ocores', 'fpga', 'mux', 'fan', 'psu', 'thermal', 'sys', 'leds' ]:


### PR DESCRIPTION
1. at24.ko does not exist in ker6.1/6.12, so we don't have to modprobe it.