### PR TITLE
[AS9817-64D][AS9817-64O] Upgrade kernel from 6.1 to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64d/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64d/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9817-64d ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9817-64d ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64d/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64d/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := $(ONL)/packages/platforms/accton/x86-64/as9817-64/src/modules/
 VENDOR := accton
 BASENAME := x86-64-accton-as9817-64d

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64d/platform-config/r0/src/lib/x86-64-accton-as9817-64d-r0.yml
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64d/platform-config/r0/src/lib/x86-64-accton-as9817-64d-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as9817-64d-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64o/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64o/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9817-64o ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as9817-64o ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64o/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64o/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := $(ONL)/packages/platforms/accton/x86-64/as9817-64/src/modules/
 VENDOR := accton
 BASENAME := x86-64-accton-as9817-64o

--- a/packages/platforms/accton/x86-64/as9817-64/as9817-64o/platform-config/r0/src/lib/x86-64-accton-as9817-64o-r0.yml
+++ b/packages/platforms/accton/x86-64/as9817-64/as9817-64o/platform-config/r0/src/lib/x86-64-accton-as9817-64o-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as9817-64o-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fan.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fan.c
@@ -54,7 +54,7 @@ static ssize_t show_dir(struct device *dev, struct device_attribute *da,
 static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
             char *buf);
 static int as9817_64_fan_probe(struct platform_device *pdev);
-static int as9817_64_fan_remove(struct platform_device *pdev);
+static void as9817_64_fan_remove(struct platform_device *pdev);
 
 enum fan_id {
     FAN_1,
@@ -554,7 +554,7 @@ static int as9817_64_fan_probe(struct platform_device *pdev)
     return status;
 }
 
-static int as9817_64_fan_remove(struct platform_device *pdev)
+static void as9817_64_fan_remove(struct platform_device *pdev)
 {
     mutex_lock(&data->update_lock);
     if (data->hwmon_dev) {
@@ -562,8 +562,6 @@ static int as9817_64_fan_remove(struct platform_device *pdev)
         data->hwmon_dev = NULL;
     }
     mutex_unlock(&data->update_lock);
-
-    return 0;
 }
 
 static int __init as9817_64_fan_init(void)

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fpga.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fpga.c
@@ -1169,7 +1169,7 @@ exit_pci_disable:
     return status;
 }
 
-static int as9817_64_pcie_fpga_stat_remove(struct platform_device *pdev)
+static void as9817_64_pcie_fpga_stat_remove(struct platform_device *pdev)
 {
     struct as9817_64_fpga_data *fpga_ctl = platform_get_drvdata(pdev);
 
@@ -1189,8 +1189,6 @@ static int as9817_64_pcie_fpga_stat_remove(struct platform_device *pdev)
         release_mem_region(fpga_ctl->pci_fpga_dev.data_region2, REGION_LEN);
         pci_disable_device(fpga_ctl->pci_fpga_dev.pci_dev);
     }
-
-    return 0;
 }
 
 static struct platform_driver pcie_fpga_port_stat_driver = {

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-i2c-ocores.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-i2c-ocores.c
@@ -852,7 +852,7 @@ err_clk:
     return ret;
 }
 
-static int ocores_i2c_remove(struct platform_device *pdev)
+static void ocores_i2c_remove(struct platform_device *pdev)
 {
     struct ocores_i2c *i2c = platform_get_drvdata(pdev);
     u8 ctrl;
@@ -870,8 +870,6 @@ static int ocores_i2c_remove(struct platform_device *pdev)
 
     if (!IS_ERR(i2c->clk))
         clk_disable_unprepare(i2c->clk);
-
-    return 0;
 }
 
 #ifdef CONFIG_PM_SLEEP

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-leds.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-leds.c
@@ -43,7 +43,7 @@ static ssize_t set_led(struct device *dev, struct device_attribute *da,
 static ssize_t show_led(struct device *dev, struct device_attribute *attr,
             char *buf);
 static int as9817_64_led_probe(struct platform_device *pdev);
-static int as9817_64_led_remove(struct platform_device *pdev);
+static void as9817_64_led_remove(struct platform_device *pdev);
 
 struct as9817_64_led_data {
     struct platform_device *pdev;
@@ -323,11 +323,9 @@ exit:
     return status;
 }
 
-static int as9817_64_led_remove(struct platform_device *pdev)
+static void as9817_64_led_remove(struct platform_device *pdev)
 {
     sysfs_remove_group(&pdev->dev.kobj, &as9817_64_led_group);
-
-    return 0;
 }
 
 static int __init as9817_64_led_init(void)

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-mux.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-mux.c
@@ -134,9 +134,9 @@ static void as9817_64_mux_cleanup(struct i2c_mux_core *muxc)
 /*
  * I2C init/probing/exit functions
  */
-static int as9817_64_mux_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as9817_64_mux_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct device *dev = &client->dev;
 	struct as9817_64_mux_data *data;
@@ -160,7 +160,7 @@ static int as9817_64_mux_probe(struct i2c_client *client,
 
 	/* Now create an adapter for each channel */
 	for (i = 0; i < chips[data->type].nchans; i++) {
-		ret = i2c_mux_add_adapter(muxc, 0, i, 0);
+		ret = i2c_mux_add_adapter(muxc, i, 0);
 		if (ret)
 			goto exit_mux;
 	}

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-mux.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-mux.c
@@ -160,7 +160,7 @@ static int as9817_64_mux_probe(struct i2c_client *client)
 
 	/* Now create an adapter for each channel */
 	for (i = 0; i < chips[data->type].nchans; i++) {
-		ret = i2c_mux_add_adapter(muxc, i, 0);
+		ret = i2c_mux_add_adapter(muxc, 0, i);
 		if (ret)
 			goto exit_mux;
 	}

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-psu.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-psu.c
@@ -49,7 +49,7 @@ static ssize_t show_psu_info(struct device *dev, struct device_attribute *attr,
 static ssize_t show_string(struct device *dev, struct device_attribute *attr,
                             char *buf);
 static int as9817_64_psu_probe(struct platform_device *pdev);
-static int as9817_64_psu_remove(struct platform_device *pdev);
+static void as9817_64_psu_remove(struct platform_device *pdev);
 
 enum psu_id {
     PSU_1,
@@ -852,7 +852,7 @@ static int as9817_64_psu_probe(struct platform_device *pdev)
     return 0;
 }
 
-static int as9817_64_psu_remove(struct platform_device *pdev)
+static void as9817_64_psu_remove(struct platform_device *pdev)
 {
     int i = 0;
 
@@ -864,8 +864,6 @@ static int as9817_64_psu_remove(struct platform_device *pdev)
         }
         mutex_unlock(&data->update_lock);
     }
-
-    return 0;
 }
 
 static int __init as9817_64_psu_init(void)

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
@@ -46,7 +46,7 @@
 #define IPMI_RESET_CMD_LENGTH 6
 
 static int as9817_64_sys_probe(struct platform_device *pdev);
-static int as9817_64_sys_remove(struct platform_device *pdev);
+static void as9817_64_sys_remove(struct platform_device *pdev);
 static ssize_t show_version(struct device *dev,
                                 struct device_attribute *da, char *buf);
 static ssize_t get_bmc_fan_controller(struct device *dev,
@@ -418,11 +418,9 @@ exit:
     return status;
 }
 
-static int as9817_64_sys_remove(struct platform_device *pdev)
+static void as9817_64_sys_remove(struct platform_device *pdev)
 {
     sysfs_remove_group(&pdev->dev.kobj, &as9817_64_sys_group);
-
-    return 0;
 }
 
 static int __init as9817_64_sys_init(void)

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-thermal.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-thermal.c
@@ -48,7 +48,7 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
     char *buf);
 #endif
 static int as9817_64_thermal_probe(struct platform_device *pdev);
-static int as9817_64_thermal_remove(struct platform_device *pdev);
+static void as9817_64_thermal_remove(struct platform_device *pdev);
 
 enum temp_data_index {
     TEMP_ADDR,
@@ -305,7 +305,7 @@ static int as9817_64_thermal_probe(struct platform_device *pdev)
     return status;
 }
 
-static int as9817_64_thermal_remove(struct platform_device *pdev)
+static void as9817_64_thermal_remove(struct platform_device *pdev)
 {
     mutex_lock(&data->update_lock);
     if (data->hwmon_dev) {
@@ -313,8 +313,6 @@ static int as9817_64_thermal_remove(struct platform_device *pdev)
         data->hwmon_dev = NULL;
     }
     mutex_unlock(&data->update_lock);
-
-    return 0;
 }
 
 static int __init as9817_64_thermal_init(void)

--- a/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/x86_64_accton_as9817_64/module/src/sysi.c
@@ -198,7 +198,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int i, len, ret = ONLP_STATUS_OK;
     char *v[NUM_OF_CPLD_VER] = {NULL};
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
     char *bmc_buf = NULL;
     char *aux_buf = NULL;


### PR DESCRIPTION
  ## Summary

  Upgrade AS9817-64D and AS9817-64O platform drivers from kernel 6.1 to 6.12 LTS.

  ## Changes

  ### Kernel version bump
  - `PKG.yml`, `Makefile`, `r0.yml`: `onl-kernel-6.1-lts-x86-64-all` → `onl-kernel-6.12-lts-x86-64-all` (for both as9817-64d and as9817-64o)

  ### API compatibility fixes for kernel 6.12

  **`platform_driver.remove` return type changed** (`int` → `void`):
  - `x86-64-accton-as9817-64-fan.c`
  - `x86-64-accton-as9817-64-leds.c`
  - `x86-64-accton-as9817-64-psu.c`
  - `x86-64-accton-as9817-64-sys.c`
  - `x86-64-accton-as9817-64-thermal.c`
  - `x86-64-accton-as9817-64-i2c-ocores.c`
  - `x86-64-accton-as9817-64-fpga.c`

  **`i2c_driver.probe` signature changed** (mux.c):
  - Removed second parameter `const struct i2c_device_id *id`
  - Use `i2c_client_get_device_id(client)` to retrieve device id inside probe

  **`i2c_mux_add_adapter` API changed** (mux.c):
  - 4 arguments → 3 arguments (removed `force_nr` parameter; dynamic bus numbering)
  - Fixed argument order: `i2c_mux_add_adapter(muxc, 0, i)` where `chan_id=i`
    > Bug: previous port had args swapped (`force_nr=i, chan_id=0`), causing EBUSY (-16) when `i=1` tried to force bus 1 which was already taken

  **Other**:
  - `sysi.c`: zero-initialize `onlp_onie_info_t onie` to avoid uninitialized memory
