### PR TITLE
[AS7515-24X] Upgrade kernel from 6.1 to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as7515-24x/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7515-24x ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7515-24x ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7515-24x

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-cpld.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-cpld.c
@@ -321,9 +321,9 @@ static void as7515_24x_cpld_remove_client(struct i2c_client *client)
 /*
  * I2C init/probing/exit functions
  */
-static int as7515_24x_cpld_probe(struct i2c_client *client,
-				const struct i2c_device_id *id)
+static int as7515_24x_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as7515_24x_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-fan.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-fan.c
@@ -613,8 +613,7 @@ static struct as7515_24x_fan_data *as7515_fan_update_device(struct device *dev)
 	return data;
 }
 
-static int as7515_24x_fan_probe(struct i2c_client *client,
-				   const struct i2c_device_id *dev_id)
+static int as7515_24x_fan_probe(struct i2c_client *client)
 {
 	struct as7515_24x_fan_data *data;
 	int status;

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-fpga.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-fpga.c
@@ -263,7 +263,7 @@ exit_pci_disable:
 	return status;
 }
 
-static int as7515_24x_pcie_fpga_stat_remove(struct platform_device *pdev)
+static void as7515_24x_pcie_fpga_stat_remove(struct platform_device *pdev)
 {
 	struct as7515_24x_fpga_data *fpga_ctl = platform_get_drvdata(pdev);
 
@@ -276,8 +276,6 @@ static int as7515_24x_pcie_fpga_stat_remove(struct platform_device *pdev)
 		release_mem_region(fpga_ctl->pci_fpga_dev.data_region0, REGION_LEN);
 		pci_disable_device(fpga_ctl->pci_fpga_dev.pci_dev);
 	}
-
-	return 0;
 }
 
 static struct platform_driver pcie_fpga_port_stat_driver = {

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-leds.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-leds.c
@@ -46,7 +46,7 @@ static ssize_t show_led(struct device *dev, struct device_attribute *attr,
 extern int as7515_24x_fpga_read(u8 reg);
 extern int as7515_24x_fpga_write(u8 reg, u8 value);
 static int as7515_24x_led_probe(struct platform_device *pdev);
-static int as7515_24x_led_remove(struct platform_device *pdev);
+static void as7515_24x_led_remove(struct platform_device *pdev);
 
 enum led_type {
 	LED_TYPE_FAN,
@@ -406,7 +406,7 @@ exit_sysfs_group:
 	return status;
 }
 
-static int as7515_24x_led_remove(struct platform_device *pdev)
+static void as7515_24x_led_remove(struct platform_device *pdev)
 {
 	struct as7515_24x_led_data *data = platform_get_drvdata(pdev);
 	int i = 0;
@@ -416,8 +416,6 @@ static int as7515_24x_led_remove(struct platform_device *pdev)
 	}
 
 	kfree(data);
-
-	return 0;
 }
 
 static struct platform_device_id as7515_24x_led_id[] = {

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-mux.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-mux.c
@@ -157,9 +157,9 @@ static void as7515_24x_mux_cleanup(struct i2c_mux_core *muxc)
 /*
  * I2C init/probing/exit functions
  */
-static int as7515_24x_mux_probe(struct i2c_client *client,
-				   const struct i2c_device_id *id)
+static int as7515_24x_mux_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct device *dev = &client->dev;
 	struct as7515_24x_mux_data *data;
@@ -184,7 +184,7 @@ static int as7515_24x_mux_probe(struct i2c_client *client,
 
 	/* Now create an adapter for each channel */
 	for (i = 0; i < chips[data->type].nchans; i++) {
-		ret = i2c_mux_add_adapter(muxc, 0, i, 0);
+		ret = i2c_mux_add_adapter(muxc, 0, i);
 		if (ret)
 			goto exit_mux;
 	}

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-psu.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-psu.c
@@ -183,9 +183,9 @@ static const struct hwmon_chip_info as7515_24x_psu_chip_info = {
 	.info = as7515_24x_psu_info,
 };
 
-static int as7515_24x_psu_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as7515_24x_psu_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	struct as7515_24x_psu_data *data;
 	int status;
 

--- a/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-sfp.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/modules/builds/src/x86-64-accton-as7515-24x-sfp.c
@@ -464,7 +464,7 @@ exit_sysfs_group:
 }
 
 
-static int as7515_sfp_remove(struct platform_device *pdev)
+static void as7515_sfp_remove(struct platform_device *pdev)
 {
 	struct as7515_sfp_data *data = platform_get_drvdata(pdev);
 	int i = 0;
@@ -474,7 +474,6 @@ static int as7515_sfp_remove(struct platform_device *pdev)
 	}
 
 	kfree(data);
-	return 0;
 }
 
 static const struct platform_device_id as7515_sfp_id[] = {

--- a/packages/platforms/accton/x86-64/as7515-24x/platform-config/r0/src/lib/x86-64-accton-as7515-24x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7515-24x/platform-config/r0/src/lib/x86-64-accton-as7515-24x-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7515-24x-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
Apply kernel 6.12 API breaking changes:
- i2c_driver.probe: remove 2nd id arg, use i2c_client_get_device_id() (cpld.c, fan.c, psu.c, mux.c)
- platform_driver.remove: int -> void, remove return 0 (fpga.c, leds.c, sfp.c)
- i2c_mux_add_adapter: drop 4th class arg (mux.c)
- modules/PKG.yml, builds/Makefile: onl-kernel-6.1 -> 6.12
- platform-config r0.yml: *kernel-6-1 -> *kernel-6-12