### PR TITLE
[AS7535-28XB] Upgrade kernel drivers to 6.12 LTS

### DIFF
--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7535-28xb ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7535-28xb ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7535-28xb

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-cpld.c
@@ -740,9 +740,9 @@ exit:
 }
 
 
-static int as7535_28xb_cpld_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as7535_28xb_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	int status;
 	struct as7535_28xb_cpld_data *data = NULL;
 

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-fan.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-fan.c
@@ -54,7 +54,7 @@ static ssize_t show_dir(struct device *dev, struct device_attribute *da,
 static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
 			char *buf);
 static int as7535_28xb_fan_probe(struct platform_device *pdev);
-static int as7535_28xb_fan_remove(struct platform_device *pdev);
+static void as7535_28xb_fan_remove(struct platform_device *pdev);
 
 enum fan_id {
 	FAN_1,
@@ -503,11 +503,9 @@ static int as7535_28xb_fan_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int as7535_28xb_fan_remove(struct platform_device *pdev)
+static void as7535_28xb_fan_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7535_28xb_fan_group);
-
-	return 0;
 }
 
 static int __init as7535_28xb_fan_init(void)

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-fpga.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-fpga.c
@@ -319,9 +319,9 @@ exit:
 	return status;
 }
 
-static int as7535_28xb_fpga_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as7535_28xb_fpga_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	int status;
 	struct as7535_28xb_fpga_data *data = NULL;
 

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-leds.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-leds.c
@@ -42,7 +42,7 @@ static ssize_t set_led(struct device *dev, struct device_attribute *da,
 static ssize_t show_led(struct device *dev, struct device_attribute *attr,
 			char *buf);
 static int as7535_28xb_led_probe(struct platform_device *pdev);
-static int as7535_28xb_led_remove(struct platform_device *pdev);
+static void as7535_28xb_led_remove(struct platform_device *pdev);
 
 struct as7535_28xb_led_data {
 	struct platform_device *pdev;
@@ -322,11 +322,9 @@ exit:
 	return status;
 }
 
-static int as7535_28xb_led_remove(struct platform_device *pdev)
+static void as7535_28xb_led_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7535_28xb_led_group);
-
-	return 0;
 }
 
 static int __init as7535_28xb_led_init(void)

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-psu.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-psu.c
@@ -49,7 +49,7 @@ static ssize_t show_psu_info(struct device *dev, struct device_attribute *attr,
 static ssize_t show_string(struct device *dev, struct device_attribute *attr,
 							char *buf);
 static int as7535_28xb_psu_probe(struct platform_device *pdev);
-static int as7535_28xb_psu_remove(struct platform_device *pdev);
+static void as7535_28xb_psu_remove(struct platform_device *pdev);
 
 enum psu_id {
 	PSU_1,
@@ -784,10 +784,9 @@ static int as7535_28xb_psu_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int as7535_28xb_psu_remove(struct platform_device *pdev)
+static void as7535_28xb_psu_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7535_28xb_psu_group);
-	return 0;
 }
 
 static int __init as7535_28xb_psu_init(void)

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-sys.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-sys.c
@@ -46,7 +46,7 @@
 #define IPMI_CPLD_READ_REG_CMD 0x22
 
 static int as7535_28xb_sys_probe(struct platform_device *pdev);
-static int as7535_28xb_sys_remove(struct platform_device *pdev);
+static void as7535_28xb_sys_remove(struct platform_device *pdev);
 static ssize_t show_version(struct device *dev,
 			struct device_attribute *da, char *buf);
 static ssize_t show_bios_flash_id(struct device *dev,
@@ -418,12 +418,10 @@ exit:
 	return status;
 }
 
-static int as7535_28xb_sys_remove(struct platform_device *pdev)
+static void as7535_28xb_sys_remove(struct platform_device *pdev)
 {
 	sysfs_eeprom_cleanup(&pdev->dev.kobj, &data->eeprom);
 	sysfs_remove_group(&pdev->dev.kobj, &as7535_28xb_sys_group);
-
-	return 0;
 }
 
 static int __init as7535_28xb_sys_init(void)

--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-thermal.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/src/x86-64-accton-as7535-28xb-thermal.c
@@ -43,7 +43,7 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *attr,
 static ssize_t set_max(struct device *dev, struct device_attribute *da,
 			const char *buf, size_t count);
 static int as7535_28xb_thermal_probe(struct platform_device *pdev);
-static int as7535_28xb_thermal_remove(struct platform_device *pdev);
+static void as7535_28xb_thermal_remove(struct platform_device *pdev);
 
 static int get_pcb_id(void);
 static int g_pcb_id = 0;
@@ -252,10 +252,9 @@ static int as7535_28xb_thermal_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int as7535_28xb_thermal_remove(struct platform_device *pdev)
+static void as7535_28xb_thermal_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7535_28xb_thermal_group);
-	return 0;
 }
 
 static int __init as7535_28xb_thermal_init(void)

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
@@ -121,7 +121,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int bmc_major = 0, bmc_minor = 0;
     unsigned int bmc_aux[4] = {0};
     char bmc_ver[16] = ""; 
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
 
     for (i = 0; i < AIM_ARRAYSIZE(cpld_ver_path); i++) {

--- a/packages/platforms/accton/x86-64/as7535-28xb/platform-config/r0/src/lib/x86-64-accton-as7535-28xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7535-28xb/platform-config/r0/src/lib/x86-64-accton-as7535-28xb-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7535-28xb-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
- modules/PKG.yml, builds/Makefile: bump KERNELS to onl-kernel-6.12-lts-x86-64-all:amd64
- platform-config r0.yml: switch to *kernel-6-12 anchor
- cpld.c, psu.c: drop 2nd arg from i2c_driver.probe (6.12 API)
- fan.c, leds.c, sys.c: change platform_driver.remove return type to void
- fpga.c: update both i2c_driver.probe and platform_driver.remove
- thermal.c: update platform_driver.remove return type to void
- sysi.c: zero-init onlp_onie_info_t to prevent double-free crash