### PR TITLE
[AS7926-40XFB] Upgrade kernel drivers to 6.12 LTS

### DIFF
--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7926-40xfb ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7926-40xfb ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7926-40xfb

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-cpld.c
@@ -955,9 +955,9 @@ static const struct hwmon_chip_info as7926_40xfb_cpld_chip_info = {
 	.info = as7926_40xfb_cpld_info,
 };
 
-static int as7926_40xfb_cpld_probe(struct i2c_client *client,
-				   const struct i2c_device_id *dev_id)
+static int as7926_40xfb_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	int status;
 	struct as7926_40xfb_cpld_data *data = NULL;
 

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-fan.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-fan.c
@@ -55,7 +55,7 @@ static ssize_t show_dir(struct device *dev, struct device_attribute *da,
 static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
 			      char *buf);
 static int as7926_40xfb_fan_probe(struct platform_device *pdev);
-static int as7926_40xfb_fan_remove(struct platform_device *pdev);
+static void as7926_40xfb_fan_remove(struct platform_device *pdev);
 
 enum fan_id {
 	FAN_1,
@@ -519,11 +519,9 @@ static int as7926_40xfb_fan_probe(struct platform_device *pdev)
 	return status;
 }
 
-static int as7926_40xfb_fan_remove(struct platform_device *pdev)
+static void as7926_40xfb_fan_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7926_40xfb_fan_group);
-
-	return 0;
 }
 
 static int __init as7926_40xfb_fan_init(void)

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-leds.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-leds.c
@@ -46,7 +46,7 @@ static ssize_t set_led(struct device *dev, struct device_attribute *da,
 static ssize_t show_led(struct device *dev, struct device_attribute *attr,
 			char *buf);
 static int as7926_40xfb_led_probe(struct platform_device *pdev);
-static int as7926_40xfb_led_remove(struct platform_device *pdev);
+static void as7926_40xfb_led_remove(struct platform_device *pdev);
 
 struct as7926_40xfb_led_data {
 	struct platform_device *pdev;
@@ -290,11 +290,9 @@ static int as7926_40xfb_led_probe(struct platform_device *pdev)
 	return status;
 }
 
-static int as7926_40xfb_led_remove(struct platform_device *pdev)
+static void as7926_40xfb_led_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7926_40xfb_led_group);
-
-	return 0;
 }
 
 static int __init as7926_40xfb_led_init(void)

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-psu.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-psu.c
@@ -52,7 +52,7 @@ static ssize_t show_psu_info(struct device *dev, struct device_attribute *attr,
 static ssize_t show_string(struct device *dev, struct device_attribute *attr,
 			   char *buf);
 static int as7926_40xfb_psu_probe(struct platform_device *pdev);
-static int as7926_40xfb_psu_remove(struct platform_device *pdev);
+static void as7926_40xfb_psu_remove(struct platform_device *pdev);
 
 enum psu_id {
 	PSU_1,
@@ -703,10 +703,9 @@ static int as7926_40xfb_psu_probe(struct platform_device *pdev)
 	return status;
 }
 
-static int as7926_40xfb_psu_remove(struct platform_device *pdev)
+static void as7926_40xfb_psu_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7926_40xfb_psu_group);
-	return 0;
 }
 
 static int __init as7926_40xfb_psu_init(void)

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-sys.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-sys.c
@@ -48,7 +48,7 @@
 #define EEPROM_SIZE				256	/*      256 byte eeprom */
 
 static int as7926_40xfb_sys_probe(struct platform_device *pdev);
-static int as7926_40xfb_sys_remove(struct platform_device *pdev);
+static void as7926_40xfb_sys_remove(struct platform_device *pdev);
 static ssize_t get_reset(struct device *dev, struct device_attribute *da,
 			char *buf);
 static ssize_t set_reset(struct device *dev, struct device_attribute *da,
@@ -404,12 +404,10 @@ exit_sysfs:
 	return status;
 }
 
-static int as7926_40xfb_sys_remove(struct platform_device *pdev)
+static void as7926_40xfb_sys_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7926_40xfb_sys_group);
 	sysfs_eeprom_cleanup(&pdev->dev.kobj, &data->eeprom);
-
-	return 0;
 }
 
 static int __init as7926_40xfb_sys_init(void)

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-thermal.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/src/x86-64-accton-as7926-40xfb-thermal.c
@@ -46,7 +46,7 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *attr,
 static ssize_t set_max(struct device *dev, struct device_attribute *da,
 		       const char *buf, size_t count);
 static int as7926_40xfb_thermal_probe(struct platform_device *pdev);
-static int as7926_40xfb_thermal_remove(struct platform_device *pdev);
+static void as7926_40xfb_thermal_remove(struct platform_device *pdev);
 
 enum temp_data_index {
 	TEMP_ADDR,
@@ -230,11 +230,9 @@ static int as7926_40xfb_thermal_probe(struct platform_device *pdev)
 	return status;
 }
 
-static int as7926_40xfb_thermal_remove(struct platform_device *pdev)
+static void as7926_40xfb_thermal_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7926_40xfb_thermal_group);
-
-	return 0;
 }
 
 static int __init as7926_40xfb_thermal_init(void)

--- a/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/sysi.c
@@ -110,7 +110,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int bmc_major = 0, bmc_minor = 0;
     unsigned int bmc_aux[4] = {0};
     char bmc_ver[16] = ""; 
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
 
     for (i = 0; i < AIM_ARRAYSIZE(cpld_path); i++) {

--- a/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/lib/x86-64-accton-as7926-40xfb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/lib/x86-64-accton-as7926-40xfb-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7926-40xfb-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
- modules/PKG.yml, builds/Makefile: bump KERNELS to onl-kernel-6.12-lts-x86-64-all:amd64
- platform-config r0.yml: switch to *kernel-6-12 anchor
- cpld.c, psu.c: drop 2nd arg from i2c_driver.probe (6.12 API)
- fan.c, leds.c, sys.c, thermal.c: change platform_driver.remove return type to void
- sysi.c: zero-init onlp_onie_info_t to prevent double-free crash