### PR TITLE
[AS7946-30XB] Upgrade kernel drivers to 6.12 LTS

### DIFF
--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7946-30xb ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7946-30xb ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7946-30xb

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-cpld.c
@@ -814,9 +814,9 @@ static const struct hwmon_chip_info as7946_30xb_cpld_chip_info = {
 	.info = as7946_30xb_cpld_info,
 };
 
-static int as7946_30xb_cpld_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as7946_30xb_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	int status;
 	struct as7946_30xb_cpld_data *data = NULL;
 

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-fan.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-fan.c
@@ -48,7 +48,7 @@ static ssize_t show_version(struct device *dev, struct device_attribute *da,
 static ssize_t show_dir(struct device *dev, struct device_attribute *da,
 			char *buf);
 static int as7946_30xb_fan_probe(struct platform_device *pdev);
-static int as7946_30xb_fan_remove(struct platform_device *pdev);
+static void as7946_30xb_fan_remove(struct platform_device *pdev);
 
 enum fan_id {
 	FAN_1,
@@ -414,11 +414,9 @@ exit:
 	return status;
 }
 
-static int as7946_30xb_fan_remove(struct platform_device *pdev)
+static void as7946_30xb_fan_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7946_30xb_fan_group);
-
-	return 0;
 }
 
 static int __init as7946_30xb_fan_init(void)

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-leds.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-leds.c
@@ -41,7 +41,7 @@ static ssize_t set_led(struct device *dev, struct device_attribute *da,
 static ssize_t show_led(struct device *dev, struct device_attribute *attr,
 			char *buf);
 static int as7946_30xb_led_probe(struct platform_device *pdev);
-static int as7946_30xb_led_remove(struct platform_device *pdev);
+static void as7946_30xb_led_remove(struct platform_device *pdev);
 
 struct as7946_30xb_led_data {
 	struct platform_device *pdev;
@@ -330,11 +330,9 @@ exit:
 	return status;
 }
 
-static int as7946_30xb_led_remove(struct platform_device *pdev)
+static void as7946_30xb_led_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7946_30xb_led_group);
-
-	return 0;
 }
 
 static int __init as7946_30xb_led_init(void)

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-psu.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-psu.c
@@ -44,7 +44,7 @@ static ssize_t show_psu(struct device *dev, struct device_attribute *attr,
 static ssize_t show_string(struct device *dev, struct device_attribute *attr,
 							char *buf);
 static int as7946_30xb_psu_probe(struct platform_device *pdev);
-static int as7946_30xb_psu_remove(struct platform_device *pdev);
+static void as7946_30xb_psu_remove(struct platform_device *pdev);
 
 enum psu_id {
 	PSU_1,
@@ -462,10 +462,9 @@ exit:
 	return status;
 }
 
-static int as7946_30xb_psu_remove(struct platform_device *pdev)
+static void as7946_30xb_psu_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7946_30xb_psu_group);
-	return 0;
 }
 
 static int __init as7946_30xb_psu_init(void)

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-sys.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-sys.c
@@ -48,7 +48,7 @@
 #define FAN_CPLD_ADDR           0x68
 
 static int as7946_30xb_sys_probe(struct platform_device *pdev);
-static int as7946_30xb_sys_remove(struct platform_device *pdev);
+static void as7946_30xb_sys_remove(struct platform_device *pdev);
 static ssize_t show_cpld_version(struct device *dev, 
 	struct device_attribute *da, char *buf);
 static ssize_t show_bios_flash_id(struct device *dev, 
@@ -422,12 +422,10 @@ exit:
 	return status;
 }
 
-static int as7946_30xb_sys_remove(struct platform_device *pdev)
+static void as7946_30xb_sys_remove(struct platform_device *pdev)
 {
 	sysfs_eeprom_cleanup(&pdev->dev.kobj, &data->eeprom);
 	sysfs_remove_group(&pdev->dev.kobj, &as7946_30xb_sys_group);
-
-	return 0;
 }
 
 static int __init as7946_30xb_sys_init(void)

--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-thermal.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/src/x86-64-accton-as7946-30xb-thermal.c
@@ -39,7 +39,7 @@
 static ssize_t show_temp(struct device *dev, struct device_attribute *attr,
 	char *buf);
 static int as7946_30xb_thermal_probe(struct platform_device *pdev);
-static int as7946_30xb_thermal_remove(struct platform_device *pdev);
+static void as7946_30xb_thermal_remove(struct platform_device *pdev);
 
 enum temp_data_index {
 	TEMP_ADDR,
@@ -170,11 +170,9 @@ exit:
 	return status;
 }
 
-static int as7946_30xb_thermal_remove(struct platform_device *pdev)
+static void as7946_30xb_thermal_remove(struct platform_device *pdev)
 {
 	sysfs_remove_group(&pdev->dev.kobj, &as7946_30xb_thermal_group);
-
-	return 0;
 }
 
 static int __init as7946_30xb_thermal_init(void)

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/sysi.c
@@ -109,7 +109,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int bmc_major = 0, bmc_minor = 0;
     unsigned int bmc_aux[4] = {0};
     char bmc_ver[16] = ""; 
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char *bios_ver = NULL;
 
     for (i = 0; i < AIM_ARRAYSIZE(cpld_ver_path); i++) {

--- a/packages/platforms/accton/x86-64/as7946-30xb/platform-config/r0/src/lib/x86-64-accton-as7946-30xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7946-30xb/platform-config/r0/src/lib/x86-64-accton-as7946-30xb-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7946-30xb-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       console=ttyS0,115200n8


### PR DESCRIPTION
Upgrade AS7946-30XB platform from kernel 6.1 to 6.12 LTS:
- modules/PKG.yml, modules/builds/Makefile: switch KERNELS to onl-kernel-6.12-lts-x86-64-all
- platform-config r0 yml: use *kernel-6-12 anchor
- cpld.c, psu.c: adapt i2c_driver.probe() to single-argument signature, retrieve i2c_device_id via i2c_client_get_device_id()
- fan.c, leds.c, sys.c, thermal.c: change platform_driver.remove() to return void per kernel 6.12 API
- sysi.c: zero-initialize onlp_onie_info_t to avoid onlpdump crash