### PR TITLE
[Accton][AS9726-32D] Show MFU ver with onlpdump -x

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
@@ -62,6 +62,9 @@
 #define IDPROM_PATH "/sys/bus/i2c/devices/13-0056/eeprom"
 #define WARM_RESET_FORMAT "/sys/bus/i2c/devices/1-0060/reset_mac"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 enum onlp_thermal_id
 {
         THERMAL_RESERVED = 0,

--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
@@ -38,7 +38,6 @@
 #define NUM_OF_CPLD        5
 #define FAN_DUTY_CYCLE_MAX         (100)
 #define FAN_DUTY_CYCLE_DEFAULT     (FAN_DUTY_CYCLE_MAX)
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 /* Number of sensor points considered by the fan/thermal policy */
 #define NUM_THERMAL_POLICY_SENSORS   7
 
@@ -102,9 +101,10 @@ int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   i, v[NUM_OF_CPLD]={0};
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
 
-    /* BIOS version */
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
     /* ONIE version */
     onlp_onie_decode_file(&onie, IDPROM_PATH);
 
@@ -121,11 +121,20 @@ int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   FAN CPLD(0x66): %02X"
                                     , v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(mfu_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
@@ -1,5 +1,37 @@
 from onl.platform.base import *
 from onl.platform.accton import *
+import os.path
+
+def get_mfu_ver_file():
+    cmd_list = [
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
+    ]
+
+    for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print("last_updated_MFU_version file does not exist !")
+                continue
+
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+
+        if process.returncode != 0:
+            if "blkid" in cmd and process.returncode == 1:
+                print("ONIE-BOOT label does not exist !")
+            else:
+                print("'" + cmd + "'" + " runs with error return code: " + str(process.returncode))
+
+                if "cp -a" in cmd:
+                    continue
+
+            return False
+
+    return True
 
 class OnlPlatform_x86_64_accton_as9726_32d_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_32x400_2x10):
@@ -75,5 +107,7 @@ class OnlPlatform_x86_64_accton_as9726_32d_r0(OnlPlatformAccton,
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+16), shell=True)
 
         self.new_i2c_device('24c02', 0x56, 13)
-        
+
+        get_mfu_ver_file()
+
         return True


### PR DESCRIPTION
## Summary
- Display MFU (Modular Firmware Upgrade) version in `onlpdump -x` output.
- The `last_updated_MFU_version` file in ONIE partition is copied to `/var/tmp/` on ONL boot.
- `onlpdump -x` reads `/var/tmp/last_updated_MFU_version` for MFU version.
- Move `BIOS_VER_PATH` from `sysi.c` to `platform_lib.h` and add `MFU_VER_PATH` macro.
- Use intermediate `const char*` to avoid passing NULL to `aim_fstrdup` when BIOS/MFU file is missing.

Same approach as PR #90 (as9716-32d) applied to AS9726-32D.

## Test plan
- [x] Built and verified on hardware: `onlpdump -x` shows BIOS / ONIE / MFU lines.
- [x] When `/var/tmp/last_updated_MFU_version` does not exist, MFU shows empty (no crash).