### PR TITLE
[Accton][AS7726-32X] Show MFU ver with onlpdump -x

### DIFF
--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
@@ -70,6 +70,9 @@
 
 #define WARM_RESET_FORMAT "/sys/bus/i2c/devices/11-0060/reset_mac"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sysi.c
@@ -37,7 +37,6 @@
 #include "x86_64_accton_as7726_32x_log.h"
 #include <onlplib/i2c.h>
 
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 #define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/"
 #define NUM_OF_CPLD                   5
@@ -113,8 +112,10 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   i, v[NUM_OF_CPLD]={0};
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
 
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
     onlp_onie_decode_file(&onie, IDPROM_PATH);
 
     for (i = 0; i < NUM_OF_CPLD; i++) {
@@ -131,11 +132,20 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   Fan CPLD(0x66): %02X\r\n",
                                     v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(mfu_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
@@ -1,5 +1,37 @@
 from onl.platform.base import *
 from onl.platform.accton import *
+import os.path
+
+def get_mfu_ver_file():
+    cmd_list = [
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
+    ]
+
+    for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print("last_updated_MFU_version file does not exist !")
+                continue
+
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+
+        if process.returncode != 0:
+            if "blkid" in cmd and process.returncode == 1:
+                print("ONIE-BOOT label does not exist !")
+            else:
+                print("'" + cmd + "'" + " runs with error return code: " + str(process.returncode))
+
+                if "cp -a" in cmd:
+                    continue
+
+            return False
+
+    return True
 
 #IR3570A chip casue problem when read eeprom by i2c-block mode.
 #It happen when read 16th-byte offset that value is 0x8. So disable chip
@@ -166,5 +198,6 @@ class OnlPlatform_x86_64_accton_as7726_32x_r0(OnlPlatformAccton,
 
         ir3570_check()
         _8v89307_init()
+        get_mfu_ver_file()
 
         return True


### PR DESCRIPTION
## Summary
- Display MFU (Modular Firmware Upgrade) version in `onlpdump -x` output.
- The `last_updated_MFU_version` file in ONIE partition is copied to `/var/tmp/` on ONL boot.
- `onlpdump -x` reads `/var/tmp/last_updated_MFU_version` for MFU version.
- Move `BIOS_VER_PATH` from `sysi.c` to `platform_lib.h` and add `MFU_VER_PATH` macro.
- Use intermediate `const char*` to avoid passing NULL to `aim_fstrdup` when BIOS/MFU file is missing.

Same approach as PR #90 (as9716-32d) applied to AS7726-32X.

## Test plan
- [x] Built and verified on hardware: `onlpdump -x` shows BIOS / ONIE / MFU lines.
- [x] When `/var/tmp/last_updated_MFU_version` does not exist, MFU shows empty (no crash).