### PR TITLE
[AS7515-24X] Fix misleading indentation in get_psu_type

### DIFF
--- a/packages/platforms/accton/x86-64/as7515-24x/onlp/builds/x86_64_accton_as7515_24x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7515-24x/onlp/builds/x86_64_accton_as7515_24x/module/src/platform_lib.c
@@ -161,16 +161,20 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
     if (!strncmp(str, "SPAACTN-03", strlen("SPAACTN-03")))
     {
         if (modelname)
+        {
             aim_strlcpy(modelname, str, strlen("SPAACTN-03")<(modelname_len-1)?(strlen("SPAACTN-03")+1):(modelname_len-1));
-            AIM_FREE_IF_PTR(str);
+        }
+        AIM_FREE_IF_PTR(str);
         return PSU_TYPE_SPAACTN_03;
     }
 
     if (!strncmp(str, "CRXT-T0T12", strlen("CRXT-T0T12")))
     {
         if (modelname)
+        {
             aim_strlcpy(modelname, str, strlen("CRXT-T0T12")<(modelname_len-1)?(strlen("CRXT-T0T12")+1):(modelname_len-1));
-            AIM_FREE_IF_PTR(str);
+        }
+        AIM_FREE_IF_PTR(str);
         return PSU_TYPE_CRXT_T0T12;
     }
 


### PR DESCRIPTION
De-indent AIM_FREE_IF_PTR(str) to correctly show it is not guarded by the if(modelname) check. str must always be freed before return regardless of whether modelname is provided.

Fixes -Werror=misleading-indentation on GCC 12.