### PR TITLE
[AS7327-56X] Add USB LED monitor

### DIFF
--- a/packages/platforms/accton/x86-64/as7327-56x/modules/builds/utils/monitor_led.py
+++ b/packages/platforms/accton/x86-64/as7327-56x/modules/builds/utils/monitor_led.py
@@ -183,6 +183,51 @@ def clear_sys_led_wdt():
     ret, output = getstatusoutput(cmd)
     return ret
 
+USB_LED_PATH = '/sys/class/leds/accton_as7327_56x_led::usb/brightness'
+USB_DATA_FLOW_PATH = '/sys/bus/usb/devices/1-1.1/urbnum'
+URB_THRESHOLD = 4
+
+old_usb_data_num = 0
+
+def get_usb_data_num():
+    try:
+        with open(USB_DATA_FLOW_PATH, 'r') as f:
+            return int(f.read().strip())
+    except (IOError, ValueError):
+        return -1
+
+def set_usb_led(led):
+    cmd = "echo {:d} > {}".format(led, USB_LED_PATH)
+    ret, output = getstatusoutput(cmd)
+    return ret
+
+def usb_led_ctrl():
+    global old_usb_data_num
+
+    if not os.path.exists(USB_DATA_FLOW_PATH):
+        set_usb_led(LED_DARK)
+        old_usb_data_num = 0
+        return
+
+    cur_usb_data_num = get_usb_data_num()
+    if cur_usb_data_num < 0:
+        set_usb_led(LED_DARK)
+        old_usb_data_num = 0
+        return
+
+    if old_usb_data_num == 0:
+        old_usb_data_num = cur_usb_data_num
+        set_usb_led(LED_GREEN_ON)
+        return
+
+    diff = cur_usb_data_num - old_usb_data_num
+    old_usb_data_num = cur_usb_data_num
+
+    if diff > URB_THRESHOLD:
+        set_usb_led(LED_GREEN_BLINK)
+    else:
+        set_usb_led(LED_GREEN_ON)
+
 fan_warn_count = 0
 def sys_led_ctrl():
     global fan_warn_count
@@ -217,6 +262,7 @@ def main(argv):
     # Loop forever, doing something useful hopefully:
     while True:
         sys_led_ctrl()
+        usb_led_ctrl()
         time.sleep(SLEEP_TIME)
 
 if __name__ == '__main__':

--- a/packages/platforms/accton/x86-64/as7327-56x/modules/builds/utils/usb_led_monitor.py
+++ b/packages/platforms/accton/x86-64/as7327-56x/modules/builds/utils/usb_led_monitor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# USB LED monitor for AS7327-56X (BMC enabled mode)
+import sys
+import os
+import time
+import syslog
+
+USB_LED_PATH = '/sys/class/leds/accton_as7327_56x_led::usb/brightness'
+USB_DATA_FLOW_PATH = '/sys/bus/usb/devices/1-1.1/urbnum'
+
+LED_DARK = 0
+LED_GREEN_ON = 1
+LED_GREEN_BLINK = 5
+
+URB_THRESHOLD = 4
+
+old_usb_data_num = 0
+current_led_state = None
+
+def get_usb_data_num():
+    try:
+        with open(USB_DATA_FLOW_PATH, 'r') as f:
+            return int(f.read().strip())
+    except (IOError, ValueError):
+        return -1
+
+def set_usb_led(led):
+    global current_led_state
+    if led == current_led_state:
+        return
+    try:
+        with open(USB_LED_PATH, 'w') as f:
+            f.write(str(led))
+        current_led_state = led
+    except IOError:
+        pass
+
+def usb_led_ctrl():
+    global old_usb_data_num
+
+    if not os.path.exists(USB_DATA_FLOW_PATH):
+        set_usb_led(LED_DARK)
+        old_usb_data_num = 0
+        return
+
+    cur_usb_data_num = get_usb_data_num()
+    if cur_usb_data_num < 0:
+        set_usb_led(LED_DARK)
+        old_usb_data_num = 0
+        return
+
+    if old_usb_data_num == 0:
+        old_usb_data_num = cur_usb_data_num
+        set_usb_led(LED_GREEN_ON)
+        return
+
+    diff = cur_usb_data_num - old_usb_data_num
+    old_usb_data_num = cur_usb_data_num
+
+    if diff > URB_THRESHOLD:
+        set_usb_led(LED_GREEN_BLINK)
+    else:
+        set_usb_led(LED_GREEN_ON)
+
+if __name__ == '__main__':
+    syslog.syslog(syslog.LOG_INFO, 'USB LED monitor starting')
+    time.sleep(60)
+    while True:
+        usb_led_ctrl()
+        time.sleep(1)

--- a/packages/platforms/accton/x86-64/as7327-56x/platform-config/r0/src/python/x86_64_accton_as7327_56x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7327-56x/platform-config/r0/src/python/x86_64_accton_as7327_56x_r0/__init__.py
@@ -60,6 +60,10 @@ class OnlPlatform_x86_64_accton_as7327_56x_r0(OnlPlatformAccton,
             self.insmod("x86-64-accton-as7327-56x-psu_bmc.ko")
             self.insmod("x86-64-accton-as7327-56x-thermal_bmc.ko")
 
+            bin_path = "/lib/platform-config/current/onl/bin"
+            self.add_path(bin_path)
+            os.system("sudo /usr/bin/python -u {}/usb_led_monitor.py &".format(bin_path))
+
         else:
             self.insmod("x86-64-accton-as7327-56x-psu.ko")
 


### PR DESCRIPTION
## Changes

Add USB LED monitoring controlled by CPU, per hardware spec:
- Off: no USB flash drive inserted
- Green blink (3Hz): USB flash drive transmitting data
- Green on: USB flash drive mounted (idle)

## Implementation
- New `usb_led_monitor.py` for BMC-enabled mode
- USB LED control added to existing `monitor_led.py` for non-BMC mode
- Platform init updated to start `usb_led_monitor.py` when BMC is enabled

## Detection method
Monitors `/sys/bus/usb/devices/1-1.1/urbnum` (USB Request Block counter).
Uses threshold-based diff to distinguish idle hub polling from active data transfer.