### PR TITLE
[AS7327-56X] Add new PSU models and fix DC type reporting

### DIFF
--- a/packages/platforms/accton/x86-64/as7327-56x/modules/builds/x86-64-accton-as7327-56x-psu.c
+++ b/packages/platforms/accton/x86-64/as7327-56x/modules/builds/x86-64-accton-as7327-56x-psu.c
@@ -261,8 +261,12 @@ static ssize_t show_word(struct device *dev, struct device_attribute *da, char *
         break;
     case PSU_FAN_DIRECTION: /* psu_fan_dir, 0=>F2B, 1=>B2F */
         if ((strncmp((data->mfr_model + 1), "C1A-B0650-C", strlen("C1A-B0650-C")) == 0) ||
-            (strncmp((data->mfr_model + 1), "G1342-0800W", strlen("G1342-0800W")) == 0)){
+            (strncmp((data->mfr_model + 1), "G1342-0800WNA", strlen("G1342-0800WNA")) == 0) ||
+            (strncmp((data->mfr_model + 1), "G1232-0800WNA", strlen("G1232-0800WNA")) == 0)){
             status = 0;
+        } else if ((strncmp((data->mfr_model + 1), "G1342-0800WRA", strlen("G1342-0800WRA")) == 0) ||
+            (strncmp((data->mfr_model + 1), "G1232-0800WRA", strlen("G1232-0800WRA")) == 0)){
+            status = 1;
         }
         break;
     default:
@@ -613,8 +617,12 @@ static struct as7327_56x_data *as7327_56x_update_device(struct device *dev)
 
         /* mfr_vin_type */
         if ((strncmp((data->mfr_model + 1), "C1A-B0650-C", strlen("C1A-B0650-C")) == 0) ||
-            (strncmp((data->mfr_model + 1), "G1342-0800W", strlen("G1342-0800W")) == 0)){
+            (strncmp((data->mfr_model + 1), "G1342-0800WNA", strlen("G1342-0800WNA")) == 0) ||
+            (strncmp((data->mfr_model + 1), "G1342-0800WRA", strlen("G1342-0800WRA")) == 0)){
             data->mfr_vin_type = 1;
+        } else if ((strncmp((data->mfr_model + 1), "G1232-0800WNA", strlen("G1232-0800WNA")) == 0) ||
+            (strncmp((data->mfr_model + 1), "G1232-0800WRA", strlen("G1232-0800WRA")) == 0)){
+            data->mfr_vin_type = 2;
         }
 
         data->last_updated = jiffies;

--- a/packages/platforms/accton/x86-64/as7327-56x/modules/builds/x86-64-accton-as7327-56x-psu_bmc.c
+++ b/packages/platforms/accton/x86-64/as7327-56x/modules/builds/x86-64-accton-as7327-56x-psu_bmc.c
@@ -726,8 +726,12 @@ static ssize_t show_psu_fan(struct device *dev, struct device_attribute *da,
             break;
         case PSU_FAN_DIRECTION: /* psu_fan_dir, 0=>F2B, 1=>B2F */
             if ((strncmp((data->psu_data[pid].mfr_model), "C1A-B0650-C", strlen("C1A-B0650-C")) == 0) ||
-                (strncmp((data->psu_data[pid].mfr_model), "G1342-0800W", strlen("G1342-0800W")) == 0))
+                (strncmp((data->psu_data[pid].mfr_model), "G1342-0800WNA", strlen("G1342-0800WNA")) == 0) ||
+                (strncmp((data->psu_data[pid].mfr_model), "G1232-0800WNA", strlen("G1232-0800WNA")) == 0))
                 status = sprintf(buf, "0\n");
+            else if ((strncmp((data->psu_data[pid].mfr_model), "G1342-0800WRA", strlen("G1342-0800WRA")) == 0) ||
+                (strncmp((data->psu_data[pid].mfr_model), "G1232-0800WRA", strlen("G1232-0800WRA")) == 0))
+                status = sprintf(buf, "1\n");
             else
                 /* Unknown direction */
                 status = sprintf(buf, "2\n");
@@ -857,8 +861,12 @@ static ssize_t show_psu_mfr(struct device *dev, struct device_attribute *da,
         case PSU_VIN_TYPE:
             /* 0:Unknown 1:AC 2:DC*/
             if ((strncmp((data->psu_data[pid].mfr_model), "C1A-B0650-C", strlen("C1A-B0650-C")) == 0) ||
-                (strncmp((data->psu_data[pid].mfr_model), "G1342-0800W", strlen("G1342-0800W")) == 0)) {
+                (strncmp((data->psu_data[pid].mfr_model), "G1342-0800WNA", strlen("G1342-0800WNA")) == 0) ||
+                (strncmp((data->psu_data[pid].mfr_model), "G1342-0800WRA", strlen("G1342-0800WRA")) == 0)) {
                 status = sprintf(buf, "1\n");
+            } else if ((strncmp((data->psu_data[pid].mfr_model), "G1232-0800WNA", strlen("G1232-0800WNA")) == 0) ||
+                (strncmp((data->psu_data[pid].mfr_model), "G1232-0800WRA", strlen("G1232-0800WRA")) == 0)) {
+                status = sprintf(buf, "2\n");
             } else {
                 status = sprintf(buf, "0\n");
             }

--- a/packages/platforms/accton/x86-64/as7327-56x/onlp/builds/x86_64_accton_as7327_56x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7327-56x/onlp/builds/x86_64_accton_as7327_56x/module/src/psui.c
@@ -233,6 +233,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         switch (psu_type) {
             case PSU_TYPE_DC:
                 info->caps = ONLP_PSU_CAPS_DC48;
+                break;
             case PSU_TYPE_AC:
                 info->caps = ONLP_PSU_CAPS_AC;
                 break;
@@ -286,6 +287,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         switch (psu_type) {
             case PSU_TYPE_DC:
                 info->caps = ONLP_PSU_CAPS_DC48;
+                break;
             case PSU_TYPE_AC:
                 info->caps = ONLP_PSU_CAPS_AC;
                 break;


### PR DESCRIPTION
## Changes

- Add support for new PSU models:
  - G1342-0800WNA: AC, F2B
  - G1342-0800WRA: AC, B2F
  - G1232-0800WNA: DC, F2B
  - G1232-0800WRA: DC, B2F
- Fix PSU_TYPE_DC fall-through bug in ONLP psui.c (missing break caused DC PSU to be reported as AC in onlpdump)

## Files modified
- x86-64-accton-as7327-56x-psu.c
- x86-64-accton-as7327-56x-psu_bmc.c
- onlp/psui.c