### PR TITLE
accton/as7326-56x: Modify onlpdump -x output format and support show MFU ver

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-cpld.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-cpld.c
@@ -48,7 +48,8 @@ struct cpld_client_node {
 enum cpld_type {
     as7326_56x_cpld1,
     as7326_56x_cpld2,
-    as7326_56x_cpld3
+    as7326_56x_cpld3,
+    as7326_56x_cpu_cpld
 };
 
 struct as7326_56x_cpld_data {
@@ -61,6 +62,7 @@ static const struct i2c_device_id as7326_56x_cpld_id[] = {
     { "as7326_56x_cpld1", as7326_56x_cpld1 },
     { "as7326_56x_cpld2", as7326_56x_cpld2 },
     { "as7326_56x_cpld3", as7326_56x_cpld3 },
+    { "as7326_56x_cpu_cpld", as7326_56x_cpu_cpld },
     { }
 };
 MODULE_DEVICE_TABLE(i2c, as7326_56x_cpld_id);
@@ -436,6 +438,16 @@ DECLARE_SFP_TRANSCEIVER_SENSOR_DEVICE_ATTR(47);
 DECLARE_SFP_TRANSCEIVER_SENSOR_DEVICE_ATTR(48);
 DECLARE_SFP_TRANSCEIVER_SENSOR_DEVICE_ATTR(57);
 DECLARE_SFP_TRANSCEIVER_SENSOR_DEVICE_ATTR(58);
+
+static struct attribute *as7326_56x_cpu_cpld_attributes[] = {
+    &sensor_dev_attr_version.dev_attr.attr,
+    &sensor_dev_attr_access.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group as7326_56x_cpu_cpld_group = {
+    .attrs = as7326_56x_cpu_cpld_attributes,
+};
 
 static struct attribute *as7326_56x_cpld3_attributes[] = {
     &sensor_dev_attr_version.dev_attr.attr,
@@ -979,6 +991,9 @@ static int as7326_56x_cpld_probe(struct i2c_client *client,
 	case as7326_56x_cpld3:
         group = &as7326_56x_cpld3_group;
         break;
+    case as7326_56x_cpu_cpld:
+        group = &as7326_56x_cpu_cpld_group;
+        break;
     default:
         break;
     }
@@ -1016,6 +1031,8 @@ static int as7326_56x_cpld_remove(struct i2c_client *client)
         break;
 	case as7326_56x_cpld3:
         group = &as7326_56x_cpld3_group;
+    case as7326_56x_cpu_cpld:
+        group = &as7326_56x_cpu_cpld_group;
         break;
     default:
         break;

--- a/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-fan.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-fan.c
@@ -64,6 +64,7 @@ extern int accton_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
 /* fan related data, the index should match sysfs_fan_attributes
  */
 static const u8 fan_reg[] = {
+    0x01,       /*fan cpld version */
     0x0F,       /* fan 1-6 present status */
     0x10,	    /* fan 1-6 direction(0:F2B 1:B2F) */
     0x11,       /* fan PWM(for all fan) */
@@ -106,6 +107,7 @@ enum fan_id {
 };
 
 enum sysfs_fan_attributes {
+    VERSION,
     FAN_PRESENT_REG,
     FAN_DIRECTION_REG,
     FAN_DUTY_CYCLE_PERCENTAGE, /* Only one CPLD register to control duty cycle for all fans */
@@ -146,6 +148,10 @@ enum sysfs_fan_attributes {
 
 /* Define attributes
  */
+#define DECLARE_VERSION_SENSOR_DEV_ATTR(index) \
+     static SENSOR_DEVICE_ATTR(version, S_IRUGO, fan_show_value, NULL, VERSION)
+#define DECLARE_VERSION_ATTR()      &sensor_dev_attr_version.dev_attr.attr
+
 #define DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(index, index2) \
     static SENSOR_DEVICE_ATTR(fan##index##_fault, S_IRUGO, fan_show_value, NULL, FAN##index##_FAULT);\
     static SENSOR_DEVICE_ATTR(fan##index2##_fault, S_IRUGO, fan_show_value, NULL, FAN##index##_FAULT)
@@ -227,6 +233,7 @@ DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR(1);
 DECLARE_FAN_SYSTEM_TEMP_SENSOR_DEV_ATTR();
 /* 3 fan wdt attribute in this platform  */
 DECLARE_FAN_WDT_SENSOR_DEV_ATTR();
+DECLARE_VERSION_SENSOR_DEV_ATTR();
 
 
 static struct attribute *as7326_56x_fan_attributes[] = {
@@ -260,6 +267,7 @@ static struct attribute *as7326_56x_fan_attributes[] = {
     DECLARE_FAN_WDT_TIMER_ATTR(),
     DECLARE_FAN_WDT_MAX_PWM_ATTR(),
     DECLARE_FAN_WDT_STATUS_ATTR(),
+    DECLARE_VERSION_ATTR(),
     NULL
 };
 
@@ -824,6 +832,9 @@ static ssize_t fan_show_value(struct device *dev, struct device_attribute *da,
         case FAN_WDT_STATUS:
             ret = sprintf(buf, "%u\n", data->reg_val[attr->index]);
             break;
+        case VERSION:
+             ret = sprintf(buf, "%u\n", data->reg_val[attr->index]);
+             break;
         default:
             break;
         }

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
@@ -95,5 +95,14 @@ int psu_acbel_serial_number_get(int id, char *serial, int serial_len);
     #define DEBUG_PRINT(format, ...)
 #endif
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
+
 #endif  /* __PLATFORM_LIB_H__ */
 

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
@@ -65,6 +65,9 @@
 #define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0056/eeprom"
 #define IDPROM_PATH_2 "/sys/bus/i2c/devices/0-0057/eeprom"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
@@ -39,8 +39,9 @@
 
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 #define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/"
-#define NUM_OF_CPLD                      3
+#define NUM_OF_CPLD                   5
 #define FAN_DUTY_CYCLE_MAX         (100)
 #define FAN_DUTY_CYCLE_DEFAULT     (32)
 #define FAN_DUTY_PLUS_FOR_DIR      (13)
@@ -52,9 +53,11 @@
 
 static char arr_cplddev_name[NUM_OF_CPLD][10] =
 {
- "18-0060",
- "12-0062",
- "19-0064"
+ "0-0065",   /* CPU CPLD */
+ "11-0066",  /* FAN CPLD */
+ "18-0060",  /* CPLD 1*/
+ "12-0062",  /* CPLD 2*/
+ "19-0064"   /* CPLD 3*/
 };
 
 const char*
@@ -122,7 +125,30 @@ onlp_sysi_oids_get(onlp_oid_t* table, int max)
 int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
-    int   i, v[NUM_OF_CPLD]={0};
+    int   i, v[NUM_OF_CPLD] = {0};
+    int   rv, failed_cnt = 0;
+    onlp_onie_info_t onie;
+    char *bios_ver = NULL;
+    char *paths[] = {IDPROM_PATH_2, IDPROM_PATH_1};
+
+    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
+
+    for (i = 0 ; i < AIM_ARRAYSIZE(paths); i++ ){
+        rv = onlp_onie_decode_file(&onie, paths[i]);
+        /* Decode failed if rv < 0 */
+        if(rv < 0)
+        {
+            failed_cnt++;
+        }
+        else
+        {
+            break;
+        }
+
+        if (failed_cnt >= 2)
+            return ONLP_STATUS_E_INTERNAL;
+    }
+
 
     for (i = 0; i < NUM_OF_CPLD; i++) {
         v[i] = 0;
@@ -131,7 +157,19 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
             return ONLP_STATUS_E_INTERNAL;
         }
     }
-    pi->cpld_versions = aim_fstrdup("%d.%d.%d", v[0], v[1], v[2]);
+
+    pi->cpld_versions = aim_fstrdup("\r\n\t   CPU CPLD(0x65): %02X"
+                                    "\r\n\t   Fan CPLD(0x66): %02X"
+                                    "\r\n\t   Main CPLD(0x60): %02X"
+                                    "\r\n\t   Main CPLD(0x62): %02X"
+                                    "\r\n\t   Main CPLD(0x64): %02X\r\n",
+                                    v[0], v[1], v[2], v[3], v[4]);
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
+                                    bios_ver, onie.onie_version);
+
+    onlp_onie_info_free(&onie);
+    AIM_FREE_IF_PTR(bios_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
@@ -39,7 +39,6 @@
 
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 #define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/"
 #define NUM_OF_CPLD                   5
 #define FAN_DUTY_CYCLE_MAX         (100)
@@ -129,9 +128,10 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   rv, failed_cnt = 0;
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
     char *paths[] = {IDPROM_PATH_2, IDPROM_PATH_1};
-
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
 
     for (i = 0 ; i < AIM_ARRAYSIZE(paths); i++ ){
         rv = onlp_onie_decode_file(&onie, paths[i]);
@@ -165,11 +165,20 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   Main CPLD(0x64): %02X\r\n",
                                     v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(mfu_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
@@ -62,6 +62,7 @@ class OnlPlatform_x86_64_accton_as7326_56x_r0(OnlPlatformAccton,
             self.insmod("x86-64-accton-as7326-56x-%s.ko" % m)
 
         self.new_i2c_device('pca9548', 0x77, 0)
+        self.new_i2c_device('as7326_56x_cpu_cpld', 0x65, 0)
         ########### initialize I2C bus 1 ###########
         # initialize multiplexer (PCA9548)
         self.new_i2c_device('pca9548', 0x70, 1)

--- a/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
@@ -5,6 +5,37 @@ import commands
 import os.path
 import time
 
+def get_mfu_ver_file():
+    cmd_list = [
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
+    ]
+
+    for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print("last_updated_MFU_version file does not exist !")
+                continue
+
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+
+        if process.returncode != 0:
+            if "blkid" in cmd and process.returncode == 1:
+                print("ONIE-BOOT label does not exist !")
+            else:
+                print("'" + cmd + "'" + " runs with error return code: " + str(process.returncode))
+
+                if "cp -a" in cmd:
+                    continue
+
+            return False
+
+    return True
+
 #IR3570A chip casue problem when read eeprom by i2c-block mode.
 #It happen when read 16th-byte offset that value is 0x8. So disable chip
 def disable_i2c_ir3570a(addr):
@@ -153,5 +184,6 @@ class OnlPlatform_x86_64_accton_as7326_56x_r0(OnlPlatformAccton,
 
         ir3570_check()
         _8v89307_init()
+        get_mfu_ver_file()
 
         return True


### PR DESCRIPTION
### What did I do
- Sync https://github.com/accton/OpenNetworkLinux/pull/4
- Sync https://github.com/accton/OpenNetworkLinux/pull/163

### Output
```
root@localhost:~# onl-platform-show
Model: AS7326-56X
Manufacturer: Accton
Ports: 56 (48x25 + 8x100)
Platform Revision: r0
System Object Id: 1.3.6.1.4.1.42623.1.1.2.259.7326.56
System Information:
    Device Version: 0
    MAC: 00:00:00:00:00:00
    DMI BIOS Version: v40.01.01.01
    DMI System Version: R01I
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): 0F
           Fan CPLD(0x66): D3
           Main CPLD(0x60): 02
           Main CPLD(0x62): 04
           Main CPLD(0x64): 03
        Other Versions:
           BIOS: v40.01.01.01
           ONIE: 2020.08.00.02
           MFU:
root@localhost:~# ls /var/tmp/last_updated_MFU_version
ls: cannot access '/var/tmp/last_updated_MFU_version': No such file or directory
root@localhost:~# echo 0x81 > /var/tmp/last_updated_MFU_version
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): 0F
           Fan CPLD(0x66): D3
           Main CPLD(0x60): 02
           Main CPLD(0x62): 04
           Main CPLD(0x64): 03
        Other Versions:
           BIOS: v40.01.01.01
           ONIE: 2020.08.00.02
           MFU: 0x81
```