### PR TITLE
accton/as7726-32x: Modify onlpdump -x output format and support show MFU ver

### DIFF
--- a/packages/platforms/accton/x86-64/as7726-32x/modules/builds/src/x86-64-accton-as7726-32x-cpld.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/modules/builds/src/x86-64-accton-as7726-32x-cpld.c
@@ -48,7 +48,8 @@ struct cpld_client_node {
 enum cpld_type {
     as7726_32x_cpld1,
     as7726_32x_cpld2,
-    as7726_32x_cpld3
+    as7726_32x_cpld3,
+    as7726_32x_cpu_cpld
 };
 
 struct as7726_32x_cpld_data {
@@ -61,6 +62,7 @@ static const struct i2c_device_id as7726_32x_cpld_id[] = {
     { "as7726_32x_cpld1", as7726_32x_cpld1 },
     { "as7726_32x_cpld2", as7726_32x_cpld2 },
     { "as7726_32x_cpld3", as7726_32x_cpld3 },
+    { "as7726_32x_cpu_cpld", as7726_32x_cpu_cpld },
     { }
 };
 MODULE_DEVICE_TABLE(i2c, as7726_32x_cpld_id);
@@ -258,6 +260,16 @@ static const struct attribute_group as7726_32x_cpld3_group = {
 	.attrs = as7726_32x_cpld3_attributes,
 };
 
+static struct attribute *as7726_32x_cpu_cpld_attributes[] = {
+    &sensor_dev_attr_version.dev_attr.attr,
+    &sensor_dev_attr_access.dev_attr.attr,
+	NULL
+};
+
+static const struct attribute_group as7726_32x_cpu_cpld_group = {
+	.attrs = as7726_32x_cpu_cpld_attributes,
+};
+
 static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
              char *buf)
 {
@@ -300,7 +312,7 @@ exit:
 static ssize_t show_rxlos_all(struct device *dev, struct device_attribute *da,
              char *buf)
 {
-	int i, status;
+	int status;
 	u8 value=0;
 	u8 reg = 0x50;
 	struct i2c_client *client = to_i2c_client(dev);
@@ -575,6 +587,9 @@ static int as7726_32x_cpld_probe(struct i2c_client *client,
 	case as7726_32x_cpld3:
          group = &as7726_32x_cpld3_group;
         break;
+    case as7726_32x_cpu_cpld:
+         group = &as7726_32x_cpu_cpld_group;
+        break;
     default:
         break;
     }
@@ -612,6 +627,9 @@ static int as7726_32x_cpld_remove(struct i2c_client *client)
         break;
 	case as7726_32x_cpld3:
         group = &as7726_32x_cpld3_group;
+        break;
+    case as7726_32x_cpu_cpld:
+         group = &as7726_32x_cpu_cpld_group;
         break;
     default:
         break;

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
@@ -95,5 +95,14 @@ int psu_acbel_serial_number_get(int id, char *serial, int serial_len);
     #define DEBUG_PRINT(format, ...)  
 #endif
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
+
 #endif  /* __PLATFORM_LIB_H__ */
 

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
@@ -65,6 +65,9 @@
 
 #define IDPROM_PATH "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sysi.c
@@ -37,7 +37,6 @@
 #include "x86_64_accton_as7726_32x_log.h"
 #include <onlplib/i2c.h>
 
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 #define PREFIX_PATH_ON_CPLD_DEV          "/sys/bus/i2c/devices/"
 #define NUM_OF_CPLD                   5
@@ -113,8 +112,10 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   i, v[NUM_OF_CPLD]={0};
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
 
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
     onlp_onie_decode_file(&onie, IDPROM_PATH);
 
     for (i = 0; i < NUM_OF_CPLD; i++) {
@@ -131,11 +132,20 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   Fan CPLD(0x66): %02X\r\n",
                                     v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(mfu_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
@@ -82,6 +82,7 @@ class OnlPlatform_x86_64_accton_as7726_32x_r0(OnlPlatformAccton,
             ('as7726_32x_cpld1', 0x60, 11),
             ('as7726_32x_cpld2', 0x62, 12),
             ('as7726_32x_cpld3', 0x64, 13),
+            ('as7726_32x_cpld3', 0x65, 0),
             ])
         self.new_i2c_devices([
             # initiate fan

--- a/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
@@ -1,5 +1,37 @@
 from onl.platform.base import *
 from onl.platform.accton import *
+import os.path
+
+def get_mfu_ver_file():
+    cmd_list = [
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
+    ]
+
+    for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print("last_updated_MFU_version file does not exist !")
+                continue
+
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+
+        if process.returncode != 0:
+            if "blkid" in cmd and process.returncode == 1:
+                print("ONIE-BOOT label does not exist !")
+            else:
+                print("'" + cmd + "'" + " runs with error return code: " + str(process.returncode))
+
+                if "cp -a" in cmd:
+                    continue
+
+            return False
+
+    return True
 
 import commands
 
@@ -150,5 +182,6 @@ class OnlPlatform_x86_64_accton_as7726_32x_r0(OnlPlatformAccton,
 
         ir3570_check()
         _8v89307_init()
+        get_mfu_ver_file()
 
         return True


### PR DESCRIPTION
### What did I do
- Sync https://github.com/accton/OpenNetworkLinux/pull/12
- Sync https://github.com/accton/OpenNetworkLinux/pull/162

### Output
```
root@localhost:~# onl-platform-show
Model: AS7726-32X
Manufacturer: Accton
Ports: 32 (32x100)
Platform Revision: r0
System Object Id: 1.3.6.1.4.1.42623.1.1.2.259.7726.32
System Information:
    DMI BIOS Version: v48.02.01.00
    DMI System Version: R02A
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): FFFFFFFA
           Main CPLD(0x60): 0F
           Main CPLD(0x62): 8E
           Main CPLD(0x64): 8E
           Fan CPLD(0x66):
        Other Versions:
           BIOS: v48.02.01.00
           ONIE: 2022.08.00.04
           MFU:
root@localhost:~# ls /var/tmp/last_updated_MFU_version
ls: cannot access '/var/tmp/last_updated_MFU_version': No such file or directory
root@localhost:~# echo 0x11 > /var/tmp/last_updated_MFU_version
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): FFFFFFFA
           Main CPLD(0x60): 0F
           Main CPLD(0x62): 8E
           Main CPLD(0x64): 8E
           Fan CPLD(0x66):
        Other Versions:
           BIOS: v48.02.01.00
           ONIE: 2022.08.00.04
           MFU: 0x11
```