### PR TITLE
accton/as9726-32d: Modify onlpdump -x output format and support show MFU ver

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/modules/builds/src/x86-64-accton-as9726-32d-cpld.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/modules/builds/src/x86-64-accton-as9726-32d-cpld.c
@@ -49,7 +49,7 @@ enum cpld_type {
 	as9726_32d_fpga,
 	as9726_32d_cpld1,
 	as9726_32d_cpld2,
-	as9726_32d_cpld_cpu
+	as9726_32d_cpu_cpld
 };
 
 struct as9726_32d_cpld_data {
@@ -62,7 +62,7 @@ static const struct i2c_device_id as9726_32d_cpld_id[] = {
 	{ "as9726_32d_fpga", as9726_32d_fpga },
 	{ "as9726_32d_cpld1", as9726_32d_cpld1 },
 	{ "as9726_32d_cpld2", as9726_32d_cpld2 },
-	{ "as9726_32d_cpld_cpu", as9726_32d_cpld_cpu },
+	{ "as9726_32d_cpu_cpld", as9726_32d_cpu_cpld },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, as9726_32d_cpld_id);
@@ -351,6 +351,16 @@ static struct attribute *as9726_32d_cpld2_attributes[] = {
 
 static const struct attribute_group as9726_32d_cpld2_group = {
 	.attrs = as9726_32d_cpld2_attributes,
+};
+
+static struct attribute *as9726_32d_cpu_cpld_attributes[] = {
+	&sensor_dev_attr_version.dev_attr.attr,
+	&sensor_dev_attr_access.dev_attr.attr,
+	NULL
+};
+
+static const struct attribute_group as9726_32d_cpu_cpld_group = {
+	.attrs = as9726_32d_cpu_cpld_attributes,
 };
 
 static ssize_t show_present_all(struct device *dev, 
@@ -847,13 +857,14 @@ static int as9726_32d_cpld_probe(struct i2c_client *client,
 	case as9726_32d_cpld2:
 		group = &as9726_32d_cpld2_group;
 		break; 
-	case as9726_32d_cpld_cpu:
-	/* Disable CPLD reset to avoid DUT will be reset.
-	 */
-	status=as9726_32d_cpld_write_internal(client, 0x3, 0x0); 
-	if (status < 0)
-		dev_dbg(&client->dev, "cpu_cpld reg 0x65 err %d\n", status);
-
+	case as9726_32d_cpu_cpld:
+		group = &as9726_32d_cpu_cpld_group;
+		/* Disable CPLD reset to avoid DUT will be reset.
+		 */
+		status=as9726_32d_cpld_write_internal(client, 0x3, 0x0);
+		if (status < 0)
+			dev_dbg(&client->dev, "cpu_cpld reg 0x65 err %d\n", status);
+		break;
 	default:
 		break;
 	}
@@ -890,6 +901,9 @@ static int as9726_32d_cpld_remove(struct i2c_client *client)
 		break;
 	case as9726_32d_cpld2:
 		group = &as9726_32d_cpld2_group;
+		break;
+	case as9726_32d_cpu_cpld:
+		group = &as9726_32d_cpu_cpld_group;
 		break;
 	default:
 		break;

--- a/packages/platforms/accton/x86-64/as9726-32d/modules/builds/src/x86-64-accton-as9726-32d-fan.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/modules/builds/src/x86-64-accton-as9726-32d-fan.c
@@ -42,6 +42,7 @@ static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
 /* fan related data, the index should match sysfs_fan_attributes
  */
 static const u8 fan_reg[] = {
+	0x01,       /* fan cpld version */
 	0x0F,       /* fan 1-6 present status */
 	0x10,	    /* fan 1-6 direction(0:F2B 1:B2F) */
 	0x11,       /* fan PWM(for all fan) */
@@ -78,6 +79,7 @@ enum fan_id {
 };
 
 enum sysfs_fan_attributes {
+	VERSION,
 	FAN_PRESENT_REG,
 	FAN_DIRECTION_REG,
 	FAN_DUTY_CYCLE_PERCENTAGE, /* Only one CPLD register to control duty cycle for all fans */
@@ -115,6 +117,11 @@ enum sysfs_fan_attributes {
 
 /* Define attributes
  */
+#define DECLARE_VERSION_SENSOR_DEV_ATTR() \
+	static SENSOR_DEVICE_ATTR(version, S_IRUGO, fan_show_value, NULL, VERSION)
+#define DECLARE_VERSION_ATTR() \
+	&sensor_dev_attr_version.dev_attr.attr
+
 #define DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(index) \
 	static SENSOR_DEVICE_ATTR(fan##index##_fault, S_IRUGO, \
 				fan_show_value, NULL, FAN##index##_FAULT)
@@ -152,6 +159,8 @@ enum sysfs_fan_attributes {
 	&sensor_dev_attr_fan##index##_front_speed_rpm.dev_attr.attr, \
 	&sensor_dev_attr_fan##index##_rear_speed_rpm.dev_attr.attr
 
+/* FAN CPLD Version */
+DECLARE_VERSION_SENSOR_DEV_ATTR();
 /* 6 fan fault attributes in this platform */
 DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(1);
 DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(2);
@@ -185,6 +194,7 @@ DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR();
 
 static struct attribute *as9726_32d_fan_attributes[] = {
 	/* fan related attributes */
+	DECLARE_VERSION_ATTR(),
 	DECLARE_FAN_FAULT_ATTR(1),
 	DECLARE_FAN_FAULT_ATTR(2),
 	DECLARE_FAN_FAULT_ATTR(3),
@@ -380,6 +390,9 @@ static ssize_t fan_show_value(struct device *dev, struct device_attribute *da,
 					data->reg_val[FAN_DIRECTION_REG],
 					attr->index - FAN1_DIRECTION));
 			break;
+        case VERSION:
+             ret = sprintf(buf, "%u\n", data->reg_val[VERSION]);
+             break;
 		default:
 			break;
 		}

--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
@@ -105,4 +105,13 @@ int psu_serial_number_get(int id, char *serial, int serial_len);
 	#define DEBUG_PRINT(format, ...)  
 #endif
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
+
 #endif  /* __PLATFORM_LIB_H__ */

--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/platform_lib.h
@@ -58,6 +58,9 @@
 
 #define IDPROM_PATH "/sys/bus/i2c/devices/13-0056/eeprom"
 
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define MFU_VER_PATH "/var/tmp/last_updated_MFU_version"
+
 enum onlp_thermal_id
 {
         THERMAL_RESERVED = 0,

--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
@@ -35,91 +35,110 @@
 
 #define NUM_OF_FAN_ON_MAIN_BROAD    6
 #define PREFIX_PATH_ON_CPLD_DEV    "/sys/bus/i2c/devices/"
-#define NUM_OF_CPLD		   3
+#define NUM_OF_CPLD        5
 #define FAN_DUTY_CYCLE_MAX         (100)
 #define FAN_DUTY_CYCLE_DEFAULT     (FAN_DUTY_CYCLE_MAX)
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 /* Number of sensor points considered by the fan/thermal policy */
 #define NUM_THERMAL_POLICY_SENSORS   7
 
 static char arr_cplddev_name[NUM_OF_CPLD][10] =
 {
-	"1-0060",
-	"10-0061",
-	"10-0062"
+    "1-0065",
+    "1-0060",
+    "10-0061",
+    "10-0062",
+    "14-0066"
 };
 
 const char* onlp_sysi_platform_get(void)
 {
-	return "x86-64-accton-as9726-32d-r0";
+    return "x86-64-accton-as9726-32d-r0";
 }
 
 int onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
-	uint8_t* rdata = aim_zmalloc(256);
+    uint8_t* rdata = aim_zmalloc(256);
 
-	if (onlp_file_read(rdata, 256, size, IDPROM_PATH) == ONLP_STATUS_OK) {
-		if (*size == 256) {
-			*data = rdata;
-			return ONLP_STATUS_OK;
-		}
-	}
+    if (onlp_file_read(rdata, 256, size, IDPROM_PATH) == ONLP_STATUS_OK) {
+        if (*size == 256) {
+            *data = rdata;
+            return ONLP_STATUS_OK;
+        }
+    }
 
-	aim_free(rdata);
-	*size = 0;
-	return ONLP_STATUS_E_INTERNAL;
+    aim_free(rdata);
+    *size = 0;
+    return ONLP_STATUS_E_INTERNAL;
 }
 
 int onlp_sysi_oids_get(onlp_oid_t* table, int max)
 {
-	int i;
-	onlp_oid_t* e = table;
-	memset(table, 0, max*sizeof(onlp_oid_t));
+    int i;
+    onlp_oid_t* e = table;
+    memset(table, 0, max*sizeof(onlp_oid_t));
 
-	/* 7 Thermal sensors on the chassis */
-	for (i = 1; i <= CHASSIS_THERMAL_COUNT; i++)
-		*e++ = ONLP_THERMAL_ID_CREATE(i);
+    /* 7 Thermal sensors on the chassis */
+    for (i = 1; i <= CHASSIS_THERMAL_COUNT; i++)
+        *e++ = ONLP_THERMAL_ID_CREATE(i);
 
-	/* 5 LEDs on the chassis */
-	for (i = 1; i <= CHASSIS_LED_COUNT; i++)
-		*e++ = ONLP_LED_ID_CREATE(i);
+    /* 5 LEDs on the chassis */
+    for (i = 1; i <= CHASSIS_LED_COUNT; i++)
+        *e++ = ONLP_LED_ID_CREATE(i);
 
-	/* 2 PSUs on the chassis */
-	for (i = 1; i <= CHASSIS_PSU_COUNT; i++)
-		*e++ = ONLP_PSU_ID_CREATE(i);
+    /* 2 PSUs on the chassis */
+    for (i = 1; i <= CHASSIS_PSU_COUNT; i++)
+        *e++ = ONLP_PSU_ID_CREATE(i);
 
-	/* 6 Fans on the chassis */
-	for (i = 1; i <= CHASSIS_FAN_COUNT; i++)
-		*e++ = ONLP_FAN_ID_CREATE(i);
+    /* 6 Fans on the chassis */
+    for (i = 1; i <= CHASSIS_FAN_COUNT; i++)
+        *e++ = ONLP_FAN_ID_CREATE(i);
 
-	return 0;
+    return 0;
 }
 
 int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
-	int   i, v[NUM_OF_CPLD]={0};
+    int   i, v[NUM_OF_CPLD]={0};
+    onlp_onie_info_t onie;
+    char *bios_ver = NULL;
 
-	for (i = 0; i < NUM_OF_CPLD; i++) {
-		v[i] = 0;
+    /* BIOS version */
+    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
+    /* ONIE version */
+    onlp_onie_decode_file(&onie, IDPROM_PATH);
 
-		if (onlp_file_read_int(v+i, "%s%s/version", 
-				      PREFIX_PATH_ON_CPLD_DEV,
-				      arr_cplddev_name[i]) < 0) {
-			return ONLP_STATUS_E_INTERNAL;
-		}
-	}
-	pi->cpld_versions = aim_fstrdup("%d.%d.%d", v[0], v[1], v[2]);
+    for (i = 0; i < NUM_OF_CPLD; i++) {
+        v[i] = 0;
 
-	return 0;
+        onlp_file_read_int(v+i, "%s%s/version", PREFIX_PATH_ON_CPLD_DEV, arr_cplddev_name[i]);
+    }
+
+    pi->cpld_versions = aim_fstrdup("\r\n\t   CPU CPLD(0x65): %02X"
+                                    "\r\n\t   FPGA(0x60): %02X"
+                                    "\r\n\t   Main CPLD2(0x61): %02X"
+                                    "\r\n\t   Main CPLD3(0x62): %02X"
+                                    "\r\n\t   FAN CPLD(0x66): %02X"
+                                    , v[0], v[1], v[2], v[3], v[4]);
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
+                                    bios_ver, onie.onie_version);
+
+    onlp_onie_info_free(&onie);
+    AIM_FREE_IF_PTR(bios_ver);
+
+    return 0;
 }
 
 void onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
-	aim_free(pi->cpld_versions);
+    aim_free(pi->cpld_versions);
+    aim_free(pi->other_versions);
 }
 
 int onlp_sysi_platform_manage_leds(void)
 {
-	return ONLP_STATUS_E_UNSUPPORTED;
+    return ONLP_STATUS_E_UNSUPPORTED;
 }
 
 /*
@@ -280,27 +299,27 @@ int onlp_sysi_platform_manage_leds(void)
  * AFO: Air Flow Out
  */
 typedef enum {
-	FAN_DIR_AFI     = 0,
-	FAN_DIR_AFO     = 1,
-	FAN_DIR_MAX     = 2
+    FAN_DIR_AFI     = 0,
+    FAN_DIR_AFO     = 1,
+    FAN_DIR_MAX     = 2
 } fan_direction_t;
 
 /* Fan Policy States */
 typedef enum {
-	LEVEL_FAN_INIT = 0,
-	LEVEL_FAN_MIN = 1,
-	LEVEL_FAN_MID = 2,
-	LEVEL_FAN_MAX = 3,
-	LEVEL_FAN_YELLOW_ALARM = 4,
-	LEVEL_FAN_RED_ALARM = 5,
-	LEVEL_FAN_SHUTDOWN = 6
+    LEVEL_FAN_INIT = 0,
+    LEVEL_FAN_MIN = 1,
+    LEVEL_FAN_MID = 2,
+    LEVEL_FAN_MAX = 3,
+    LEVEL_FAN_YELLOW_ALARM = 4,
+    LEVEL_FAN_RED_ALARM = 5,
+    LEVEL_FAN_SHUTDOWN = 6
 } fan_policy_level_t;
 
 /* Sensor Types */
 typedef enum {
-	TYPE_SENSOR = 0,
-	TYPE_TRANSCEIVER = 1,
-	TYPE_MAX = 2
+    TYPE_SENSOR = 0,
+    TYPE_TRANSCEIVER = 1,
+    TYPE_MAX = 2
 } sensor_type_t;
 
 /* Monitor ports for ZR/ZR+ transceivers */
@@ -308,757 +327,757 @@ static int monitor_ports[] = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27,
 
 /* Fan Policy Configuration */
 typedef struct {
-	int duty_cycle;
-	int pwm_value;
+    int duty_cycle;
+    int pwm_value;
 } fan_policy_config_t;
 
 static fan_policy_config_t fan_policy_f2b[] = {  /* AFO */
-	[LEVEL_FAN_MIN] = {50, 0x7},
-	[LEVEL_FAN_MID] = {75, 0xb},
-	[LEVEL_FAN_MAX] = {100, 0xf}
+    [LEVEL_FAN_MIN] = {50, 0x7},
+    [LEVEL_FAN_MID] = {75, 0xb},
+    [LEVEL_FAN_MAX] = {100, 0xf}
 };
 
 static fan_policy_config_t fan_policy_b2f[] = {  /* AFI */
-	[LEVEL_FAN_MID] = {75, 0xb},
-	[LEVEL_FAN_MAX] = {100, 0xf}
+    [LEVEL_FAN_MID] = {75, 0xb},
+    [LEVEL_FAN_MAX] = {100, 0xf}
 };
 
 /* Thermal Specification Structure */
 typedef struct {
-	int threshold;
+    int threshold;
 } thermal_threshold_t;
 
 /* Complete Thermal Specification for each sensor/transceiver */
 typedef struct {
-	onlp_oid_t id;
-	thermal_threshold_t min_to_mid;		/* For AFO only */
-	thermal_threshold_t mid_to_max;
-	thermal_threshold_t max_to_mid;
-	thermal_threshold_t mid_to_min;		/* For AFO only */
-	thermal_threshold_t max_to_yellow;
-	thermal_threshold_t yellow_to_red;
-	thermal_threshold_t red_to_shutdown;
+    onlp_oid_t id;
+    thermal_threshold_t min_to_mid;     /* For AFO only */
+    thermal_threshold_t mid_to_max;
+    thermal_threshold_t max_to_mid;
+    thermal_threshold_t mid_to_min;     /* For AFO only */
+    thermal_threshold_t max_to_yellow;
+    thermal_threshold_t yellow_to_red;
+    thermal_threshold_t red_to_shutdown;
 } thermal_spec_t;
 
 
 static thermal_spec_t thermal_specs[FAN_DIR_MAX][TYPE_MAX][NUM_THERMAL_POLICY_SENSORS] = {
-	/* AFI */
-	[FAN_DIR_AFI] = {
-		[TYPE_SENSOR] = {
-			/* LM75-1 (0x48) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD),
-				.min_to_mid = {0},      /* AFI doesn't use min state */
-				.mid_to_max = {55900},
-				.max_to_mid = {49500},
-				.mid_to_min = {0},      /* AFI doesn't use min state */
-				.max_to_yellow = {57900},
-				.yellow_to_red = {62900},
-				.red_to_shutdown = {67900}
-			},
-			/* LM75-2 (0x49) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD),
-				.min_to_mid = {0},
-				.mid_to_max = {48800},
-				.max_to_mid = {42900},
-				.mid_to_min = {0},
-				.max_to_yellow = {51900},
-				.yellow_to_red = {56900},
-				.red_to_shutdown = {61900}
-			},
-			/* LM75-3 (0x4A) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD),
-				.min_to_mid = {0},
-				.mid_to_max = {51500},
-				.max_to_mid = {46300},
-				.mid_to_min = {0},
-				.max_to_yellow = {48900},
-				.yellow_to_red = {53900},
-				.red_to_shutdown = {58900}
-			},
-			/* LM75-4 (0x4C) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD),
-				.min_to_mid = {0},
-				.mid_to_max = {45300},
-				.max_to_mid = {40100},
-				.mid_to_min = {0},
-				.max_to_yellow = {55900},
-				.yellow_to_red = {58900},
-				.red_to_shutdown = {63900}
-			},
-			/* LM75-6 (0x4F) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD),
-				.min_to_mid = {0},
-				.mid_to_max = {43400},
-				.max_to_mid = {39400},
-				.mid_to_min = {0},
-				.max_to_yellow = {48500},
-				.yellow_to_red = {53500},
-				.red_to_shutdown = {58500}
-			},
-			/* Core - CPU board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE),
-				.min_to_mid = {0},
-				.mid_to_max = {50000},
-				.max_to_mid = {46000},
-				.mid_to_min = {0},
-				.max_to_yellow = {52000},
-				.yellow_to_red = {57000},
-				.red_to_shutdown = {62000}
-			},
-			/* LM75-1 (0x4B) - CPU board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD),
-				.min_to_mid = {0},
-				.mid_to_max = {43400},
-				.max_to_mid = {34800},
-				.mid_to_min = {0},
-				.max_to_yellow = {41800},
-				.yellow_to_red = {46800},
-				.red_to_shutdown = {51800}
-			}
-		},
-		[TYPE_TRANSCEIVER] = {
-			{
-				.id = 0,
-				.min_to_mid = {0},
-				.mid_to_max = {65000},
-				.max_to_mid = {64000},
-				.mid_to_min = {0},
-				.max_to_yellow = {73000},
-				.yellow_to_red = {75000},
-				.red_to_shutdown = {77000}
-			}
-		}
-	},
-	/* AFO */
-	[FAN_DIR_AFO] = {
-		[TYPE_SENSOR] = {
-			/* LM75-1 (0x48) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD),
-				.min_to_mid = {63000},
-				.mid_to_max = {63000},
-				.max_to_mid = {56000},
-				.mid_to_min = {50000},
-				.max_to_yellow = {67000},
-				.yellow_to_red = {72000},
-				.red_to_shutdown = {77000}
-			},
-			/* LM75-2 (0x49) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD),
-				.min_to_mid = {60500},
-				.mid_to_max = {60000},
-				.max_to_mid = {53500},
-				.mid_to_min = {47300},
-				.max_to_yellow = {65000},
-				.yellow_to_red = {70000},
-				.red_to_shutdown = {75000}
-			},
-			/* LM75-3 (0x4A) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD),
-				.min_to_mid = {60000},
-				.mid_to_max = {60000},
-				.max_to_mid = {52500},
-				.mid_to_min = {46400},
-				.max_to_yellow = {64000},
-				.yellow_to_red = {69000},
-				.red_to_shutdown = {74000}
-			},
-			/* LM75-4 (0x4C) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD),
-				.min_to_mid = {60000},
-				.mid_to_max = {59000},
-				.max_to_mid = {52000},
-				.mid_to_min = {44600},
-				.max_to_yellow = {62000},
-				.yellow_to_red = {67000},
-				.red_to_shutdown = {72000}
-			},
-			/* LM75-6 (0x4F) - MB board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD),
-				.min_to_mid = {61000},
-				.mid_to_max = {60000},
-				.max_to_mid = {52800},
-				.mid_to_min = {47000},
-				.max_to_yellow = {64000},
-				.yellow_to_red = {69000},
-				.red_to_shutdown = {74000}
-			},
-			/* Core - CPU board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE),
-				.min_to_mid = {72000},
-				.mid_to_max = {69000},
-				.max_to_mid = {62000},
-				.mid_to_min = {56000},
-				.max_to_yellow = {73000},
-				.yellow_to_red = {78000},
-				.red_to_shutdown = {83000}
-			},
-			/* LM75-1 (0x4B) - CPU board */
-			{
-				.id = ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD),
-				.min_to_mid = {50000},
-				.mid_to_max = {51500},
-				.max_to_mid = {45800},
-				.mid_to_min = {38800},
-				.max_to_yellow = {67000},
-				.yellow_to_red = {72000},
-				.red_to_shutdown = {77000}
-			}
-		},
-		[TYPE_TRANSCEIVER] = {
-			{
-				.id = 0,
-				.min_to_mid = {55000},
-				.mid_to_max = {65000},
-				.max_to_mid = {64000},
-				.mid_to_min = {54000},
-				.max_to_yellow = {73000},
-				.yellow_to_red = {75000},
-				.red_to_shutdown = {77000}
-			}
-		}
-	}
+    /* AFI */
+    [FAN_DIR_AFI] = {
+        [TYPE_SENSOR] = {
+            /* LM75-1 (0x48) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD),
+                .min_to_mid = {0},      /* AFI doesn't use min state */
+                .mid_to_max = {55900},
+                .max_to_mid = {49500},
+                .mid_to_min = {0},      /* AFI doesn't use min state */
+                .max_to_yellow = {57900},
+                .yellow_to_red = {62900},
+                .red_to_shutdown = {67900}
+            },
+            /* LM75-2 (0x49) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD),
+                .min_to_mid = {0},
+                .mid_to_max = {48800},
+                .max_to_mid = {42900},
+                .mid_to_min = {0},
+                .max_to_yellow = {51900},
+                .yellow_to_red = {56900},
+                .red_to_shutdown = {61900}
+            },
+            /* LM75-3 (0x4A) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD),
+                .min_to_mid = {0},
+                .mid_to_max = {51500},
+                .max_to_mid = {46300},
+                .mid_to_min = {0},
+                .max_to_yellow = {48900},
+                .yellow_to_red = {53900},
+                .red_to_shutdown = {58900}
+            },
+            /* LM75-4 (0x4C) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD),
+                .min_to_mid = {0},
+                .mid_to_max = {45300},
+                .max_to_mid = {40100},
+                .mid_to_min = {0},
+                .max_to_yellow = {55900},
+                .yellow_to_red = {58900},
+                .red_to_shutdown = {63900}
+            },
+            /* LM75-6 (0x4F) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD),
+                .min_to_mid = {0},
+                .mid_to_max = {43400},
+                .max_to_mid = {39400},
+                .mid_to_min = {0},
+                .max_to_yellow = {48500},
+                .yellow_to_red = {53500},
+                .red_to_shutdown = {58500}
+            },
+            /* Core - CPU board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE),
+                .min_to_mid = {0},
+                .mid_to_max = {50000},
+                .max_to_mid = {46000},
+                .mid_to_min = {0},
+                .max_to_yellow = {52000},
+                .yellow_to_red = {57000},
+                .red_to_shutdown = {62000}
+            },
+            /* LM75-1 (0x4B) - CPU board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD),
+                .min_to_mid = {0},
+                .mid_to_max = {43400},
+                .max_to_mid = {34800},
+                .mid_to_min = {0},
+                .max_to_yellow = {41800},
+                .yellow_to_red = {46800},
+                .red_to_shutdown = {51800}
+            }
+        },
+        [TYPE_TRANSCEIVER] = {
+            {
+                .id = 0,
+                .min_to_mid = {0},
+                .mid_to_max = {65000},
+                .max_to_mid = {64000},
+                .mid_to_min = {0},
+                .max_to_yellow = {73000},
+                .yellow_to_red = {75000},
+                .red_to_shutdown = {77000}
+            }
+        }
+    },
+    /* AFO */
+    [FAN_DIR_AFO] = {
+        [TYPE_SENSOR] = {
+            /* LM75-1 (0x48) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD),
+                .min_to_mid = {63000},
+                .mid_to_max = {63000},
+                .max_to_mid = {56000},
+                .mid_to_min = {50000},
+                .max_to_yellow = {67000},
+                .yellow_to_red = {72000},
+                .red_to_shutdown = {77000}
+            },
+            /* LM75-2 (0x49) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD),
+                .min_to_mid = {60500},
+                .mid_to_max = {60000},
+                .max_to_mid = {53500},
+                .mid_to_min = {47300},
+                .max_to_yellow = {65000},
+                .yellow_to_red = {70000},
+                .red_to_shutdown = {75000}
+            },
+            /* LM75-3 (0x4A) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD),
+                .min_to_mid = {60000},
+                .mid_to_max = {60000},
+                .max_to_mid = {52500},
+                .mid_to_min = {46400},
+                .max_to_yellow = {64000},
+                .yellow_to_red = {69000},
+                .red_to_shutdown = {74000}
+            },
+            /* LM75-4 (0x4C) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD),
+                .min_to_mid = {60000},
+                .mid_to_max = {59000},
+                .max_to_mid = {52000},
+                .mid_to_min = {44600},
+                .max_to_yellow = {62000},
+                .yellow_to_red = {67000},
+                .red_to_shutdown = {72000}
+            },
+            /* LM75-6 (0x4F) - MB board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD),
+                .min_to_mid = {61000},
+                .mid_to_max = {60000},
+                .max_to_mid = {52800},
+                .mid_to_min = {47000},
+                .max_to_yellow = {64000},
+                .yellow_to_red = {69000},
+                .red_to_shutdown = {74000}
+            },
+            /* Core - CPU board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE),
+                .min_to_mid = {72000},
+                .mid_to_max = {69000},
+                .max_to_mid = {62000},
+                .mid_to_min = {56000},
+                .max_to_yellow = {73000},
+                .yellow_to_red = {78000},
+                .red_to_shutdown = {83000}
+            },
+            /* LM75-1 (0x4B) - CPU board */
+            {
+                .id = ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD),
+                .min_to_mid = {50000},
+                .mid_to_max = {51500},
+                .max_to_mid = {45800},
+                .mid_to_min = {38800},
+                .max_to_yellow = {67000},
+                .yellow_to_red = {72000},
+                .red_to_shutdown = {77000}
+            }
+        },
+        [TYPE_TRANSCEIVER] = {
+            {
+                .id = 0,
+                .min_to_mid = {55000},
+                .mid_to_max = {65000},
+                .max_to_mid = {64000},
+                .mid_to_min = {54000},
+                .max_to_yellow = {73000},
+                .yellow_to_red = {75000},
+                .red_to_shutdown = {77000}
+            }
+        }
+    }
 };
 
 /* State machine API for thermal management */
 typedef struct {
-	sensor_type_t type;
-	int current_temp;
-	int port;
-	thermal_spec_t *spec;
-	char sensor_name[ONLP_OID_DESC_SIZE];
+    sensor_type_t type;
+    int current_temp;
+    int port;
+    thermal_spec_t *spec;
+    char sensor_name[ONLP_OID_DESC_SIZE];
 } thermal_sensor_data_t;
 
 typedef struct {
-	int ori_state;
-	int new_state;
-	int max_to_mid_count;
-	int mid_to_min_count;
-	int alarm;
+    int ori_state;
+    int new_state;
+    int max_to_mid_count;
+    int mid_to_min_count;
+    int alarm;
 } thermal_state_result_t;
 
 typedef struct thermal_sensor_ops {
-	const char* name;
-	int (*get_temp)(int index, fan_direction_t fan_dir, thermal_sensor_data_t *data);
-	int (*get_count)(fan_direction_t dir);
-	bool (*should_process)(int index);
-	bool (*is_critical_error)(int error_code);  /* Determine if error is critical */
+    const char* name;
+    int (*get_temp)(int index, fan_direction_t fan_dir, thermal_sensor_data_t *data);
+    int (*get_count)(fan_direction_t dir);
+    bool (*should_process)(int index);
+    bool (*is_critical_error)(int error_code);  /* Determine if error is critical */
 } thermal_sensor_ops_t;
 
 typedef struct {
-	thermal_sensor_ops_t *ops;
-	sensor_type_t type;
+    thermal_sensor_ops_t *ops;
+    sensor_type_t type;
 } sensor_handler_t;
 
 void onlp_sysi_over_temp_protector(void)
 {
-	int fpga_ver = 0;
-	int i;
+    int fpga_ver = 0;
+    int i;
 
-	for (i = 0; i < AIM_ARRAYSIZE(monitor_ports); i++) {
-		onlp_sfpi_control_set(monitor_ports[i] - 1, ONLP_SFP_CONTROL_RESET, 1);
-	}
+    for (i = 0; i < AIM_ARRAYSIZE(monitor_ports); i++) {
+        onlp_sfpi_control_set(monitor_ports[i] - 1, ONLP_SFP_CONTROL_RESET, 1);
+    }
 
-	if (onlp_file_read_int(&fpga_ver, "%s%s/version",
-				PREFIX_PATH_ON_CPLD_DEV, "1-0060") < 0) {
-		AIM_LOG_ERROR("Can not get the FPGA version. (%s%s/version)", 
-				PREFIX_PATH_ON_CPLD_DEV, "1-0060");
-	}
+    if (onlp_file_read_int(&fpga_ver, "%s%s/version",
+                PREFIX_PATH_ON_CPLD_DEV, "1-0060") < 0) {
+        AIM_LOG_ERROR("Can not get the FPGA version. (%s%s/version)", 
+                PREFIX_PATH_ON_CPLD_DEV, "1-0060");
+    }
 
-	system("sync;sync;sync;");
-	system("/sbin/fstrim -av");
-	if (fpga_ver >= 9) {
-			/* Power off main board & Power off cpu */
-			system("i2cset -y -f 1 0x60 0x60 0x11 & i2cset -y -f 1 0x65 0x07 0x2c");
-	} else {
-			/* Power-cycle dut */
-			system("i2cset -y -f 1 0x60 0x60 0x10");
-	}
+    system("sync;sync;sync;");
+    system("/sbin/fstrim -av");
+    if (fpga_ver >= 9) {
+            /* Power off main board & Power off cpu */
+            system("i2cset -y -f 1 0x60 0x60 0x11 & i2cset -y -f 1 0x65 0x07 0x2c");
+    } else {
+            /* Power-cycle dut */
+            system("i2cset -y -f 1 0x60 0x60 0x10");
+    }
 }
 
 /* Get fan direction: 1 for B2F (AFI), 2 for F2B (AFO) */
 static fan_direction_t onlp_sysi_get_fan_direction(void)
 {
-	onlp_fan_info_t fan_info;
-	int b2f_count = 0, f2b_count = 0;
-	int i, rv;
+    onlp_fan_info_t fan_info;
+    int b2f_count = 0, f2b_count = 0;
+    int i, rv;
 
-	for (i = 1; i <= NUM_OF_FAN_ON_MAIN_BROAD; i++) {
-		rv = onlp_fani_info_get(ONLP_FAN_ID_CREATE(i), &fan_info);
-		if (rv < 0) {
-			continue;
-		}
+    for (i = 1; i <= NUM_OF_FAN_ON_MAIN_BROAD; i++) {
+        rv = onlp_fani_info_get(ONLP_FAN_ID_CREATE(i), &fan_info);
+        if (rv < 0) {
+            continue;
+        }
 
-		if (!(fan_info.status & ONLP_FAN_STATUS_PRESENT)) {
-			continue;
-		}
+        if (!(fan_info.status & ONLP_FAN_STATUS_PRESENT)) {
+            continue;
+        }
 
-		if (fan_info.status & ONLP_FAN_STATUS_B2F) {
-			b2f_count++;
-		} else {
-			f2b_count++;
-		}
-	}
+        if (fan_info.status & ONLP_FAN_STATUS_B2F) {
+            b2f_count++;
+        } else {
+            f2b_count++;
+        }
+    }
 
-	return (b2f_count >= f2b_count) ? FAN_DIR_AFI : FAN_DIR_AFO;
+    return (b2f_count >= f2b_count) ? FAN_DIR_AFI : FAN_DIR_AFO;
 }
 
 int onlp_sysi_get_fan_status(void)
 {
-	int i, ret;
-	onlp_fan_info_t fi[CHASSIS_FAN_COUNT];
-	memset(fi, 0, sizeof(fi));
+    int i, ret;
+    onlp_fan_info_t fi[CHASSIS_FAN_COUNT];
+    memset(fi, 0, sizeof(fi));
 
-	for (i = 0; i < CHASSIS_FAN_COUNT; i++) {
-		ret = onlp_fani_info_get(ONLP_FAN_ID_CREATE(i+1), &fi[i]);
-		if (ret != ONLP_STATUS_OK) {
-			AIM_LOG_ERROR("Unable to get '%s' status", fi[i].hdr.description);
-			return ONLP_STATUS_E_INTERNAL;
-		}
+    for (i = 0; i < CHASSIS_FAN_COUNT; i++) {
+        ret = onlp_fani_info_get(ONLP_FAN_ID_CREATE(i+1), &fi[i]);
+        if (ret != ONLP_STATUS_OK) {
+            AIM_LOG_ERROR("Unable to get '%s' status", fi[i].hdr.description);
+            return ONLP_STATUS_E_INTERNAL;
+        }
 
-		if (!(fi[i].status & ONLP_FAN_STATUS_PRESENT)) {
-			AIM_LOG_ERROR("'%s' is NOT present", fi[i].hdr.description);
-			return ONLP_STATUS_E_INTERNAL;
-		}
+        if (!(fi[i].status & ONLP_FAN_STATUS_PRESENT)) {
+            AIM_LOG_ERROR("'%s' is NOT present", fi[i].hdr.description);
+            return ONLP_STATUS_E_INTERNAL;
+        }
 
-		if (fi[i].status & ONLP_FAN_STATUS_FAILED) {
-			AIM_LOG_ERROR("'%s' is NOT operational", fi[i].hdr.description);
-			return ONLP_STATUS_E_INTERNAL;
-		}
-	}
+        if (fi[i].status & ONLP_FAN_STATUS_FAILED) {
+            AIM_LOG_ERROR("'%s' is NOT operational", fi[i].hdr.description);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    }
 
-	return ONLP_STATUS_OK;
+    return ONLP_STATUS_OK;
 }
 
 int onlp_sysi_set_fan_duty_all(int duty)
 {
-	int fid, ret = ONLP_STATUS_OK;
+    int fid, ret = ONLP_STATUS_OK;
 
-	for (fid = 1; fid <= CHASSIS_FAN_COUNT; fid++) {
-		if (ONLP_STATUS_OK != onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(fid), duty)) {
-			ret = ONLP_STATUS_E_INTERNAL;
-		}
-	}
+    for (fid = 1; fid <= CHASSIS_FAN_COUNT; fid++) {
+        if (ONLP_STATUS_OK != onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(fid), duty)) {
+            ret = ONLP_STATUS_E_INTERNAL;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 int onlp_sysi_get_sff8436_temp(int port, int *temp)
 {
-	int value;
-	int16_t port_temp;
+    int value;
+    int16_t port_temp;
 
-	/* Read memory model */
-	value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
-	if (value & 0x04) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
+    /* Read memory model */
+    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
+    if (value & 0x04) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
 
-	value = onlp_sfpi_dev_readb(port, 0x50, 22);
-	if (value < 0) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
-	port_temp = (int16_t)((value & 0xFF) << 8);
+    value = onlp_sfpi_dev_readb(port, 0x50, 22);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
+    port_temp = (int16_t)((value & 0xFF) << 8);
 
-	value = onlp_sfpi_dev_readb(port, 0x50, 23);
-	if (value < 0) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
-	port_temp = (port_temp | (int16_t)(value & 0xFF));
+    value = onlp_sfpi_dev_readb(port, 0x50, 23);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
+    port_temp = (port_temp | (int16_t)(value & 0xFF));
 
-	*temp = (int)port_temp * 1000 / 256;
-	return ONLP_STATUS_OK;
+    *temp = (int)port_temp * 1000 / 256;
+    return ONLP_STATUS_OK;
 }
 
 int onlp_sysi_get_cmis_temp(int port, int *temp)
 {
-	int value;
-	int16_t port_temp;
+    int value;
+    int16_t port_temp;
 
-	/* Read memory model */
-	value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
-	if (value & 0x80) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
+    /* Read memory model */
+    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
+    if (value & 0x80) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
 
-	value = onlp_sfpi_dev_readb(port, 0x50, 14);
-	if (value < 0) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
-	port_temp = (int16_t)((value & 0xFF) << 8);
+    value = onlp_sfpi_dev_readb(port, 0x50, 14);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
+    port_temp = (int16_t)((value & 0xFF) << 8);
 
-	value = onlp_sfpi_dev_readb(port, 0x50, 15);
-	if (value < 0) {
-		*temp = ONLP_STATUS_E_MISSING;
-		return ONLP_STATUS_OK;
-	}
-	port_temp = (port_temp | (int16_t)(value & 0xFF));
+    value = onlp_sfpi_dev_readb(port, 0x50, 15);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_OK;
+    }
+    port_temp = (port_temp | (int16_t)(value & 0xFF));
 
-	*temp = (int)port_temp * 1000 / 256;
-	return ONLP_STATUS_OK;
+    *temp = (int)port_temp * 1000 / 256;
+    return ONLP_STATUS_OK;
 }
 
 int onlp_sysi_get_xcvr_temp(int port)
 {
-	int ret = ONLP_STATUS_OK;
-	int current_temp = 0;
-	int value;
+    int ret = ONLP_STATUS_OK;
+    int current_temp = 0;
+    int value;
 
-	/* Skip if transceiver not present */
-	if (onlp_sfpi_is_present(port) != 1) {
-		return ONLP_STATUS_E_MISSING;
-	}
+    /* Skip if transceiver not present */
+    if (onlp_sfpi_is_present(port) != 1) {
+        return ONLP_STATUS_E_MISSING;
+    }
 
-	value = onlp_sfpi_dev_readb(port, 0x50, 0);
-	if (value < 0) {
-		AIM_LOG_ERROR("Unable to get read 'Port %02d' eeprom", port);
-		return ONLP_STATUS_E_MISSING;
-	}
+    value = onlp_sfpi_dev_readb(port, 0x50, 0);
+    if (value < 0) {
+        AIM_LOG_ERROR("Unable to get read 'Port %02d' eeprom", port);
+        return ONLP_STATUS_E_MISSING;
+    }
 
-	if (value == 0x18 || value == 0x19 || value == 0x1E) {
-		ret = onlp_sysi_get_cmis_temp(port, &current_temp);
-		if (ret == ONLP_STATUS_OK) {
-			return current_temp;
-		}
-	}
-	else if (value == 0x0C || value == 0x0D || value == 0x11 || value ==  0xE1) {
-		ret = onlp_sysi_get_sff8436_temp(port, &current_temp);
-		if (ret == ONLP_STATUS_OK) {
-			return current_temp;
-		}
-	}
+    if (value == 0x18 || value == 0x19 || value == 0x1E) {
+        ret = onlp_sysi_get_cmis_temp(port, &current_temp);
+        if (ret == ONLP_STATUS_OK) {
+            return current_temp;
+        }
+    }
+    else if (value == 0x0C || value == 0x0D || value == 0x11 || value ==  0xE1) {
+        ret = onlp_sysi_get_sff8436_temp(port, &current_temp);
+        if (ret == ONLP_STATUS_OK) {
+            return current_temp;
+        }
+    }
 
-	return ONLP_STATUS_E_MISSING;
+    return ONLP_STATUS_E_MISSING;
 }
 
 static int sensor_get_temp(int index, fan_direction_t fan_dir, thermal_sensor_data_t *data)
 {
-	int ret;
-	onlp_thermal_info_t thermal_info;
+    int ret;
+    onlp_thermal_info_t thermal_info;
 
-	data->spec = &thermal_specs[fan_dir][TYPE_SENSOR][index];
-	ret = onlp_thermali_info_get(data->spec->id, &thermal_info);
+    data->spec = &thermal_specs[fan_dir][TYPE_SENSOR][index];
+    ret = onlp_thermali_info_get(data->spec->id, &thermal_info);
 
-	if (ret != ONLP_STATUS_OK) {
-		AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
-				"Failed to read temperature from sensor '%s' (error: %d)", 
-				thermal_info.hdr.description, ret);
-		return ret;
-	}
+    if (ret != ONLP_STATUS_OK) {
+        AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
+                "Failed to read temperature from sensor '%s' (error: %d)", 
+                thermal_info.hdr.description, ret);
+        return ret;
+    }
 
-	data->type = TYPE_SENSOR;
-	data->current_temp = thermal_info.mcelsius;
-	snprintf(data->sensor_name, sizeof(data->sensor_name), "%s", thermal_info.hdr.description);
+    data->type = TYPE_SENSOR;
+    data->current_temp = thermal_info.mcelsius;
+    snprintf(data->sensor_name, sizeof(data->sensor_name), "%s", thermal_info.hdr.description);
 
-	return ONLP_STATUS_OK;
+    return ONLP_STATUS_OK;
 }
 
 static int sensor_get_count(fan_direction_t dir)
 {
-	return AIM_ARRAYSIZE(thermal_specs[dir][TYPE_SENSOR]);
+    return AIM_ARRAYSIZE(thermal_specs[dir][TYPE_SENSOR]);
 }
 
 static bool sensor_should_process(int index)
 {
-	return true; /* Process all sensors */
+    return true; /* Process all sensors */
 }
 
 /* Sensor critical error check: any error is critical */
 static bool sensor_is_critical_error(int error_code)
 {
-	return (error_code != ONLP_STATUS_OK);
+    return (error_code != ONLP_STATUS_OK);
 }
 
 /* TYPE_TRANSCEIVER implementation */
 static int transceiver_get_temp(int index, fan_direction_t fan_dir, thermal_sensor_data_t *data)
 {
-	int current_temp;
-	int port;
+    int current_temp;
+    int port;
 
-	port = monitor_ports[index] - 1;
-	current_temp = onlp_sysi_get_xcvr_temp(port);
-	if (current_temp == ONLP_STATUS_E_MISSING) {
-		return ONLP_STATUS_E_MISSING;
-	}
+    port = monitor_ports[index] - 1;
+    current_temp = onlp_sysi_get_xcvr_temp(port);
+    if (current_temp == ONLP_STATUS_E_MISSING) {
+        return ONLP_STATUS_E_MISSING;
+    }
 
-	data->type = TYPE_TRANSCEIVER;
-	data->spec = &thermal_specs[fan_dir][TYPE_TRANSCEIVER][0];
-	data->port = port;
-	data->current_temp = current_temp;
-	snprintf(data->sensor_name, sizeof(data->sensor_name), "Port %02d", port);
+    data->type = TYPE_TRANSCEIVER;
+    data->spec = &thermal_specs[fan_dir][TYPE_TRANSCEIVER][0];
+    data->port = port;
+    data->current_temp = current_temp;
+    snprintf(data->sensor_name, sizeof(data->sensor_name), "Port %02d", port);
 
-	return ONLP_STATUS_OK;
+    return ONLP_STATUS_OK;
 }
 
 static int transceiver_get_count(fan_direction_t dir)
 {
-	return AIM_ARRAYSIZE(monitor_ports);
+    return AIM_ARRAYSIZE(monitor_ports);
 }
 
 static bool transceiver_should_process(int index)
 {
-	return true;
+    return true;
 }
 
 /* Transceiver critical error check: only non-E_MISSING errors are critical */
 static bool transceiver_is_critical_error(int error_code)
 {
-	/* E_MISSING (not present or temporary issue) is not critical */
-	/* Other errors (e.g., E_INTERNAL) are critical */
-	return (error_code != ONLP_STATUS_OK && error_code != ONLP_STATUS_E_MISSING);
+    /* E_MISSING (not present or temporary issue) is not critical */
+    /* Other errors (e.g., E_INTERNAL) are critical */
+    return (error_code != ONLP_STATUS_OK && error_code != ONLP_STATUS_E_MISSING);
 }
 
 /* Sensor operation structures */
 static thermal_sensor_ops_t sensor_ops = {
-	.name = "Thermal Sensor",
-	.get_temp = sensor_get_temp,
-	.get_count = sensor_get_count,
-	.should_process = sensor_should_process,
-	.is_critical_error = sensor_is_critical_error
+    .name = "Thermal Sensor",
+    .get_temp = sensor_get_temp,
+    .get_count = sensor_get_count,
+    .should_process = sensor_should_process,
+    .is_critical_error = sensor_is_critical_error
 };
 
 static thermal_sensor_ops_t transceiver_ops = {
-	.name = "Transceiver",
-	.get_temp = transceiver_get_temp,
-	.get_count = transceiver_get_count,
-	.should_process = transceiver_should_process,
-	.is_critical_error = transceiver_is_critical_error
+    .name = "Transceiver",
+    .get_temp = transceiver_get_temp,
+    .get_count = transceiver_get_count,
+    .should_process = transceiver_should_process,
+    .is_critical_error = transceiver_is_critical_error
 };
 
 /* Registered handlers */
 static sensor_handler_t sensor_handlers[] = {
-	{ .ops = &sensor_ops, .type = TYPE_SENSOR },
-	{ .ops = &transceiver_ops, .type = TYPE_TRANSCEIVER }
+    { .ops = &sensor_ops, .type = TYPE_SENSOR },
+    { .ops = &transceiver_ops, .type = TYPE_TRANSCEIVER }
 };
 
 /* State Machine API */
 void process_thermal_state(thermal_sensor_data_t *sensor_data, thermal_state_result_t *result)
 {
-	int current_temp = 0;
-	thermal_spec_t *spec = NULL;
-	const char *sensor_name = NULL;
+    int current_temp = 0;
+    thermal_spec_t *spec = NULL;
+    const char *sensor_name = NULL;
 
-	if (!sensor_data || !result) {
-		return;
-	}
+    if (!sensor_data || !result) {
+        return;
+    }
 
-	current_temp = sensor_data->current_temp;
-	spec = sensor_data->spec;
-	sensor_name = sensor_data->sensor_name;
+    current_temp = sensor_data->current_temp;
+    spec = sensor_data->spec;
+    sensor_name = sensor_data->sensor_name;
 
-	if (current_temp == 0) return;  /* Skip invalid readings */
+    if (current_temp == 0) return;  /* Skip invalid readings */
 
-	/* State machine logic */
-	if (result->ori_state == LEVEL_FAN_MIN) {
-		if (current_temp >= spec->min_to_mid.threshold) {
-			result->new_state = LEVEL_FAN_MID;
-		}
-	} else if (result->ori_state == LEVEL_FAN_MID) {
-		if (current_temp <= spec->mid_to_min.threshold) {
-			result->mid_to_min_count += 1;
-		} else if (current_temp >= spec->mid_to_max.threshold) {
-			result->new_state = LEVEL_FAN_MAX;
-			AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
-					"%s: %.1f°C exceeds mid->max threshold %.1f°C", 
-					sensor_name, current_temp/1000.0, spec->mid_to_max.threshold/1000.0);
-		}
-	} else {  /* LEVEL_FAN_MAX */
-		/* Check for temperature reduction */
-		if (current_temp <= spec->max_to_mid.threshold) {
-			result->max_to_mid_count += 1;
-		}
+    /* State machine logic */
+    if (result->ori_state == LEVEL_FAN_MIN) {
+        if (current_temp >= spec->min_to_mid.threshold) {
+            result->new_state = LEVEL_FAN_MID;
+        }
+    } else if (result->ori_state == LEVEL_FAN_MID) {
+        if (current_temp <= spec->mid_to_min.threshold) {
+            result->mid_to_min_count += 1;
+        } else if (current_temp >= spec->mid_to_max.threshold) {
+            result->new_state = LEVEL_FAN_MAX;
+            AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
+                    "%s: %.1f°C exceeds mid->max threshold %.1f°C", 
+                    sensor_name, current_temp/1000.0, spec->mid_to_max.threshold/1000.0);
+        }
+    } else {  /* LEVEL_FAN_MAX */
+        /* Check for temperature reduction */
+        if (current_temp <= spec->max_to_mid.threshold) {
+            result->max_to_mid_count += 1;
+        }
 
-		/* Check alarm conditions */
-		if (result->alarm == 0) {
-			if (current_temp >= spec->max_to_yellow.threshold) {
-				result->alarm = LEVEL_FAN_YELLOW_ALARM;
-				AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
-						"Yellow alarm - %s: %.1f°C exceeds %.1f°C", 
-						sensor_name, current_temp/1000.0, spec->max_to_yellow.threshold/1000.0);
-			}
-		} else if (result->alarm == LEVEL_FAN_YELLOW_ALARM) {
-			if (current_temp >= spec->yellow_to_red.threshold) {
-				result->alarm = LEVEL_FAN_RED_ALARM;
-				AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical",
-						"Red alarm - %s: %.1f°C exceeds %.1f°C", 
-						sensor_name, current_temp/1000.0, spec->yellow_to_red.threshold/1000.0);
-			}
-		} else if (result->alarm == LEVEL_FAN_RED_ALARM) {
-			if (current_temp >= spec->red_to_shutdown.threshold) {
-				result->alarm = LEVEL_FAN_SHUTDOWN;
-				if (sensor_data->type == TYPE_SENSOR) {
-					AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical", 
-							"SHUTDOWN - %s: %.1f°C exceeds %.1f°C - powering off", 
-							sensor_name, current_temp/1000.0, 
-							spec->red_to_shutdown.threshold/1000.0);
-					onlp_sysi_over_temp_protector();
-				} else if (sensor_data->type == TYPE_TRANSCEIVER) {
-					AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical", 
-							"SHUTDOWN - %s: %.1f°C exceeds %.1f°C - reset", 
-							sensor_name, current_temp/1000.0, 
-							spec->red_to_shutdown.threshold/1000.0);
-					onlp_sfpi_control_set(sensor_data->port, ONLP_SFP_CONTROL_RESET, 1);
-					result->alarm = 0;
-				}
-			}
-		}
-	}
+        /* Check alarm conditions */
+        if (result->alarm == 0) {
+            if (current_temp >= spec->max_to_yellow.threshold) {
+                result->alarm = LEVEL_FAN_YELLOW_ALARM;
+                AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
+                        "Yellow alarm - %s: %.1f°C exceeds %.1f°C", 
+                        sensor_name, current_temp/1000.0, spec->max_to_yellow.threshold/1000.0);
+            }
+        } else if (result->alarm == LEVEL_FAN_YELLOW_ALARM) {
+            if (current_temp >= spec->yellow_to_red.threshold) {
+                result->alarm = LEVEL_FAN_RED_ALARM;
+                AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical",
+                        "Red alarm - %s: %.1f°C exceeds %.1f°C", 
+                        sensor_name, current_temp/1000.0, spec->yellow_to_red.threshold/1000.0);
+            }
+        } else if (result->alarm == LEVEL_FAN_RED_ALARM) {
+            if (current_temp >= spec->red_to_shutdown.threshold) {
+                result->alarm = LEVEL_FAN_SHUTDOWN;
+                if (sensor_data->type == TYPE_SENSOR) {
+                    AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical", 
+                            "SHUTDOWN - %s: %.1f°C exceeds %.1f°C - powering off", 
+                            sensor_name, current_temp/1000.0, 
+                            spec->red_to_shutdown.threshold/1000.0);
+                    onlp_sysi_over_temp_protector();
+                } else if (sensor_data->type == TYPE_TRANSCEIVER) {
+                    AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical", 
+                            "SHUTDOWN - %s: %.1f°C exceeds %.1f°C - reset", 
+                            sensor_name, current_temp/1000.0, 
+                            spec->red_to_shutdown.threshold/1000.0);
+                    onlp_sfpi_control_set(sensor_data->port, ONLP_SFP_CONTROL_RESET, 1);
+                    result->alarm = 0;
+                }
+            }
+        }
+    }
 }
 
 /* Generic sensor processing function */
 static int process_sensor_type(sensor_handler_t *handler, 
-				fan_direction_t fan_dir,
-				thermal_state_result_t *result,
-				int *processed_count)
+                fan_direction_t fan_dir,
+                thermal_state_result_t *result,
+                int *processed_count)
 {
-	int i, count;
-	thermal_sensor_ops_t *ops = handler->ops;
+    int i, count;
+    thermal_sensor_ops_t *ops = handler->ops;
 
-	count = ops->get_count(fan_dir);
-	*processed_count = 0;
+    count = ops->get_count(fan_dir);
+    *processed_count = 0;
 
-	for (i = 0; i < count; i++) {
-		thermal_sensor_data_t sensor_data = {0};
-		int ret;
+    for (i = 0; i < count; i++) {
+        thermal_sensor_data_t sensor_data = {0};
+        int ret;
 
-		if (!ops->should_process(i)) {
-			continue;
-		}
+        if (!ops->should_process(i)) {
+            continue;
+        }
 
-		ret = ops->get_temp(i, fan_dir, &sensor_data);
+        ret = ops->get_temp(i, fan_dir, &sensor_data);
 
-		if (ret != ONLP_STATUS_OK) {
-			if (ops->is_critical_error(ret)) {
-				return ret;
-			} else {
-				continue;
-			}
-		}
+        if (ret != ONLP_STATUS_OK) {
+            if (ops->is_critical_error(ret)) {
+                return ret;
+            } else {
+                continue;
+            }
+        }
 
-		(*processed_count)++;
+        (*processed_count)++;
 
-		/* Process temperature state */
-		process_thermal_state(&sensor_data, result);
+        /* Process temperature state */
+        process_thermal_state(&sensor_data, result);
 
-		if (result->new_state != result->ori_state) {
-			return ONLP_STATUS_OK;
-		}
-	}
+        if (result->new_state != result->ori_state) {
+            return ONLP_STATUS_OK;
+        }
+    }
 
-	return ONLP_STATUS_OK;
+    return ONLP_STATUS_OK;
 }
 
 /* Simplified main function */
 int onlp_sysi_platform_manage_fans(void)
 {
-	static int current_state = LEVEL_FAN_MAX;
-	static bool initialized = false;
-	static int persistent_alarm = 0;
-	fan_direction_t fan_dir;
-	thermal_state_result_t result = {0};
-	int i, total_processed = 0;
+    static int current_state = LEVEL_FAN_MAX;
+    static bool initialized = false;
+    static int persistent_alarm = 0;
+    fan_direction_t fan_dir;
+    thermal_state_result_t result = {0};
+    int i, total_processed = 0;
 
-	/* Check fan status */
-	if (onlp_sysi_get_fan_status() != ONLP_STATUS_OK) {
-		current_state = LEVEL_FAN_MAX;
-		onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
-		AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
-				"Fan failure detected, setting maximum speed");
-		return ONLP_STATUS_OK;
-	}
+    /* Check fan status */
+    if (onlp_sysi_get_fan_status() != ONLP_STATUS_OK) {
+        current_state = LEVEL_FAN_MAX;
+        onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
+        AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
+                "Fan failure detected, setting maximum speed");
+        return ONLP_STATUS_OK;
+    }
 
-	/* Initialize */
-	if (!initialized) {
-		onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
-		AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
-				"Initializing fan to %d%%", FAN_DUTY_CYCLE_MAX);
-		initialized = true;
-	}
+    /* Initialize */
+    if (!initialized) {
+        onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
+        AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
+                "Initializing fan to %d%%", FAN_DUTY_CYCLE_MAX);
+        initialized = true;
+    }
 
-	/* Get fan direction */
-	fan_dir = onlp_sysi_get_fan_direction();
+    /* Get fan direction */
+    fan_dir = onlp_sysi_get_fan_direction();
 
-	/* Initialize result */
-	result.ori_state = current_state;
-	result.new_state = current_state;
-	result.alarm = persistent_alarm;
+    /* Initialize result */
+    result.ori_state = current_state;
+    result.new_state = current_state;
+    result.alarm = persistent_alarm;
 
-	/* Process all sensor types */
-	for (i = 0; i < AIM_ARRAYSIZE(sensor_handlers); i++) {
-		int processed;
-		int ret;
+    /* Process all sensor types */
+    for (i = 0; i < AIM_ARRAYSIZE(sensor_handlers); i++) {
+        int processed;
+        int ret;
 
-		ret = process_sensor_type(&sensor_handlers[i], fan_dir, &result, &processed);
-		if (ret != ONLP_STATUS_OK) {
-			current_state = LEVEL_FAN_MAX;
-			onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
-			return ONLP_STATUS_OK;
-		}
+        ret = process_sensor_type(&sensor_handlers[i], fan_dir, &result, &processed);
+        if (ret != ONLP_STATUS_OK) {
+            current_state = LEVEL_FAN_MAX;
+            onlp_sysi_set_fan_duty_all(FAN_DUTY_CYCLE_MAX);
+            return ONLP_STATUS_OK;
+        }
 
-		total_processed += processed;
+        total_processed += processed;
 
-		if (result.new_state != current_state) {
-			break;
-		}
-	}
+        if (result.new_state != current_state) {
+            break;
+        }
+    }
 
-	/* Check state transitions */
-	if (result.max_to_mid_count == total_processed && current_state == LEVEL_FAN_MAX) {
-		result.new_state = LEVEL_FAN_MID;
-		if (result.alarm != 0) {
-			result.alarm = 0;
-			AIM_SYSLOG_INFO("Temperature info", "Temperature info", "Temperature alarms cleared");
-		}
-	}
+    /* Check state transitions */
+    if (result.max_to_mid_count == total_processed && current_state == LEVEL_FAN_MAX) {
+        result.new_state = LEVEL_FAN_MID;
+        if (result.alarm != 0) {
+            result.alarm = 0;
+            AIM_SYSLOG_INFO("Temperature info", "Temperature info", "Temperature alarms cleared");
+        }
+    }
 
-	if (fan_dir == FAN_DIR_AFO) {
-		if (result.mid_to_min_count == total_processed && current_state == LEVEL_FAN_MID) {
-			result.new_state = LEVEL_FAN_MIN;
-			AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
-					"All temperatures low - transitioning to MIN");
-		}
-	}
+    if (fan_dir == FAN_DIR_AFO) {
+        if (result.mid_to_min_count == total_processed && current_state == LEVEL_FAN_MID) {
+            result.new_state = LEVEL_FAN_MIN;
+            AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
+                    "All temperatures low - transitioning to MIN");
+        }
+    }
 
-	persistent_alarm = result.alarm;
+    persistent_alarm = result.alarm;
 
-	/* Apply fan policy changes */
-	if (current_state != result.new_state) {
-		fan_policy_config_t *fan_policy;
+    /* Apply fan policy changes */
+    if (current_state != result.new_state) {
+        fan_policy_config_t *fan_policy;
 
-		fan_policy = (fan_dir == FAN_DIR_AFI) ? fan_policy_b2f : fan_policy_f2b;
+        fan_policy = (fan_dir == FAN_DIR_AFI) ? fan_policy_b2f : fan_policy_f2b;
 
-		if (result.new_state > result.ori_state) {
-			AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
-					"Increasing fan duty cycle from %d%% to %d%%", 
-					fan_policy[result.ori_state].duty_cycle, 
-					fan_policy[result.new_state].duty_cycle);
-		} else {
-			AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
-					"Decreasing fan duty cycle from %d%% to %d%%", 
-					fan_policy[result.ori_state].duty_cycle, 
-					fan_policy[result.new_state].duty_cycle);
-		}
-		onlp_sysi_set_fan_duty_all(fan_policy[result.new_state].duty_cycle);
+        if (result.new_state > result.ori_state) {
+            AIM_SYSLOG_WARN("Temperature warning", "Temperature warning", 
+                    "Increasing fan duty cycle from %d%% to %d%%", 
+                    fan_policy[result.ori_state].duty_cycle, 
+                    fan_policy[result.new_state].duty_cycle);
+        } else {
+            AIM_SYSLOG_INFO("Temperature info", "Temperature info", 
+                    "Decreasing fan duty cycle from %d%% to %d%%", 
+                    fan_policy[result.ori_state].duty_cycle, 
+                    fan_policy[result.new_state].duty_cycle);
+        }
+        onlp_sysi_set_fan_duty_all(fan_policy[result.new_state].duty_cycle);
 
-		current_state = result.new_state;
-	}
+        current_state = result.new_state;
+    }
 
-	return ONLP_STATUS_OK;
+    return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sysi.c
@@ -38,7 +38,6 @@
 #define NUM_OF_CPLD        5
 #define FAN_DUTY_CYCLE_MAX         (100)
 #define FAN_DUTY_CYCLE_DEFAULT     (FAN_DUTY_CYCLE_MAX)
-#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 /* Number of sensor points considered by the fan/thermal policy */
 #define NUM_THERMAL_POLICY_SENSORS   7
 
@@ -102,9 +101,10 @@ int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     int   i, v[NUM_OF_CPLD]={0};
     onlp_onie_info_t onie;
     char *bios_ver = NULL;
+    char *mfu_ver = NULL;
+    const char *bios = "";
+    const char *mfu = "";
 
-    /* BIOS version */
-    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
     /* ONIE version */
     onlp_onie_decode_file(&onie, IDPROM_PATH);
 
@@ -121,11 +121,20 @@ int onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
                                     "\r\n\t   FAN CPLD(0x66): %02X"
                                     , v[0], v[1], v[2], v[3], v[4]);
 
-    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+    if (onlp_file_read_str(&bios_ver, BIOS_VER_PATH) > 0) {
+        bios = bios_ver;
+    }
+    if (onlp_file_read_str(&mfu_ver, MFU_VER_PATH) > 0) {
+        mfu = mfu_ver;
+    }
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   MFU: %s",
+                                    bios, onie.onie_version, mfu);
 
     onlp_onie_info_free(&onie);
     AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(mfu_ver);
 
     return 0;
 }

--- a/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
@@ -37,6 +37,7 @@ class OnlPlatform_x86_64_accton_as9726_32d_r0(OnlPlatformAccton,
         self.new_i2c_devices([
             # initialize CPLD
              #initiate CPLD
+            ('as9726_32d_cpu_cpld', 0x65, 1),
             ('as9726_32d_fpga', 0x60, 1),            
             ('as9726_32d_cpld1', 0x61, 10),
             ('as9726_32d_cpld2', 0x62, 10),

--- a/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9726-32d/platform-config/r0/src/python/x86_64_accton_as9726_32d_r0/__init__.py
@@ -1,5 +1,37 @@
 from onl.platform.base import *
 from onl.platform.accton import *
+import os.path
+
+def get_mfu_ver_file():
+    cmd_list = [
+        "mkdir -p /mnt/onie-boot",
+        "blkid | grep 'ONIE-BOOT'",
+        "mount -L ONIE-BOOT /mnt/onie-boot",
+        "cp -a /mnt/onie-boot/onie/update/last_updated_MFU_version /var/tmp",
+        "umount /mnt/onie-boot"
+    ]
+
+    for cmd in cmd_list:
+        if "cp -a" in cmd:
+            if not os.path.isfile("/mnt/onie-boot/onie/update/last_updated_MFU_version"):
+                print("last_updated_MFU_version file does not exist !")
+                continue
+
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process.communicate()
+
+        if process.returncode != 0:
+            if "blkid" in cmd and process.returncode == 1:
+                print("ONIE-BOOT label does not exist !")
+            else:
+                print("'" + cmd + "'" + " runs with error return code: " + str(process.returncode))
+
+                if "cp -a" in cmd:
+                    continue
+
+            return False
+
+    return True
 
 import commands
 
@@ -79,5 +111,7 @@ class OnlPlatform_x86_64_accton_as9726_32d_r0(OnlPlatformAccton,
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+16), shell=True)
 
         self.new_i2c_device('24c02', 0x56, 13)
-        
+
+        get_mfu_ver_file()
+
         return True


### PR DESCRIPTION
### What did I do
- Sync https://github.com/accton/OpenNetworkLinux/pull/26
- Sync https://github.com/accton/OpenNetworkLinux/pull/161

### Output
```
root@localhost:~# uname -a
Linux localhost 4.19.81-OpenNetworkLinux #1 SMP Mon Jun 1 06:15:33 UTC 2026 x86_64 GNU/Linux
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): E1
           FPGA(0x60): 08
           Main CPLD2(0x61): 07
           Main CPLD3(0x62): 04
           FAN CPLD(0x66): A4
        Other Versions:
           BIOS: v45.0a.02.00
           ONIE: 2020.08.00.14
           MFU:
root@localhost:~# ls /var/tmp/last_updated_MFU_version
ls: cannot access '/var/tmp/last_updated_MFU_version': No such file or directory
root@localhost:~# ls /var/tmp
root@localhost:~# echo '0xa0' > /var/tmp/last_updated_MFU_version
root@localhost:~# ls /var/tmp
last_updated_MFU_version
root@localhost:~# onlpdump -x
        CPLD Versions:
           CPU CPLD(0x65): E1
           FPGA(0x60): 08
           Main CPLD2(0x61): 07
           Main CPLD3(0x62): 04
           FAN CPLD(0x66): A4
        Other Versions:
           BIOS: v45.0a.02.00
           ONIE: 2020.08.00.14
           MFU: 0xa0

```