### PR TITLE
accton/as7326-56x: fix missing break statement

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-cpld.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/modules/builds/src/x86-64-accton-as7326-56x-cpld.c
@@ -1031,6 +1031,7 @@ static int as7326_56x_cpld_remove(struct i2c_client *client)
         break;
 	case as7326_56x_cpld3:
         group = &as7326_56x_cpld3_group;
+        break;
     case as7326_56x_cpu_cpld:
         group = &as7326_56x_cpu_cpld_group;
         break;


### PR DESCRIPTION
### What did I do
- Fix missing break statement