### PR TITLE
[Accton][as9726-32d] Check TX_DISABLE support before access in onlp_sfpi_control_get/set

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
@@ -82,6 +82,8 @@
 #define QSFP_DD_PAGE_ADMIN_INFO 0x0
 #define QSFP_DD_PAGE_ADVERTISING 0x1
 #define QSFP_DD_PAGE_LANE_CTRL 0x10
+#define QSFP_DD_LOWER_OFFSET_STATUS 0x02
+#define QSFP_DD_FLAT_MEM 0x80                          /* byte 0x02 bit 7 */
 #define QSFP_DD_P01H_OFFSET_CONTROL_1 0x9B
 #define QSFP_DD_P01H_TX_DISABLE_SUPPORT 0x2
 #define QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX 0x82
@@ -353,6 +355,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 	int bus  = 10;
 	int present = 0;
 	int identifier = 0;
+	int status_byte = 0;
 	int support_ctrls = 0;
 
 	VALIDATE(port);
@@ -370,6 +373,15 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 				}
 
 				if (identifier == QSFP_DD_IDENTIFIER) {
+					/* Flat-memory CMIS modules do not implement page 01h/10h */
+					if ((status_byte = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS)) < 0) {
+						AIM_LOG_ERROR("Failed to read Status byte, unable to write tx_disable status to port(%d)\r\n", port);
+						return ONLP_STATUS_E_INTERNAL;
+					}
+					if (status_byte & QSFP_DD_FLAT_MEM) {
+						AIM_LOG_ERROR("Setting tx_disable to port(%d) is not supported (flat-memory module)\r\n", port);
+						return ONLP_STATUS_E_UNSUPPORTED;
+					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
 						AIM_LOG_ERROR("Failed to set Bank 0, unable to write tx_disable status to port(%d)\r\n", port);
 						return ONLP_STATUS_E_INTERNAL;
@@ -485,6 +497,8 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 	int bus  = 10;
 	int present = 0;
 	int identifier = 0;
+	int status_byte = 0;
+	int support_ctrls = 0;
 	int tx_dis = 0;
 
 	VALIDATE(port);
@@ -532,18 +546,46 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 				}
 
 				if (identifier == QSFP_DD_IDENTIFIER) {
+					/* Flat-memory CMIS modules do not implement page 01h/10h */
+					if ((status_byte = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS)) < 0) {
+						AIM_LOG_ERROR("Failed to read Status byte, unable to read tx_disable status from port(%d)\r\n", port);
+						return ONLP_STATUS_E_INTERNAL;
+					}
+					if (status_byte & QSFP_DD_FLAT_MEM) {
+						AIM_LOG_ERROR("Getting tx_disable from port(%d) is not supported (flat-memory module)\r\n", port);
+						return ONLP_STATUS_E_UNSUPPORTED;
+					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
 						AIM_LOG_ERROR("Failed to set Bank 0, unable to read tx_disable status from port(%d)\r\n", port);
 						return ONLP_STATUS_E_INTERNAL;
 					}
-					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL)) < 0) {
-						AIM_LOG_ERROR("Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)\r\n", 
-									QSFP_DD_PAGE_LANE_CTRL, port);
+					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADVERTISING)) < 0) {
+						AIM_LOG_ERROR("Failed to switch to Advertising Page on port(%d)\r\n", port);
 						goto restore;
 					}
-					if ((tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX)) < 0) {
-						AIM_LOG_ERROR("Failed to read TX_DISABLE value from Lane Control register on port(%d)\r\n", port);
-						rv = tx_dis;
+					if ((support_ctrls = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P01H_OFFSET_CONTROL_1)) < 0) {
+						AIM_LOG_ERROR("Failed to read Support Control on port(%d)\r\n", port);
+						rv = support_ctrls;
+						goto restore;
+					}
+					if (support_ctrls & QSFP_DD_P01H_TX_DISABLE_SUPPORT) {
+						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
+							AIM_LOG_ERROR("Failed to set Bank 0 on port(%d)\r\n", port);
+							goto restore;
+						}
+						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL)) < 0) {
+							AIM_LOG_ERROR("Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)\r\n",
+										QSFP_DD_PAGE_LANE_CTRL, port);
+							goto restore;
+						}
+						if ((tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX)) < 0) {
+							AIM_LOG_ERROR("Failed to read TX_DISABLE value from Lane Control register on port(%d)\r\n", port);
+							rv = tx_dis;
+							goto restore;
+						}
+					} else {
+						AIM_LOG_ERROR("Getting tx_disable from port(%d) is not supported\r\n", port);
+						rv = ONLP_STATUS_E_UNSUPPORTED;
 						goto restore;
 					}
 
@@ -555,7 +597,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 					if (rv < 0) {
 						AIM_LOG_ERROR("Unable to get tx_disable status from port(%d)\r\n", port);
-						rv = ONLP_STATUS_E_INTERNAL;
+						rv = (rv == ONLP_STATUS_E_UNSUPPORTED) ? rv : ONLP_STATUS_E_INTERNAL;
 					} else {
 						*value = (tx_dis & 0xff);
 						rv = ONLP_STATUS_OK;


### PR DESCRIPTION
## Summary
- `onlp_sfpi_control_get()` QSFP-DD branch previously read page 10h byte 0x82 unconditionally. On modules that do not implement TX disable this returns garbage; flat-memory CMIS modules (no page 01h/10h at all) silently dropped the page select and returned page 00h vendor data.
- The set path checked the advertising bit but also missed the flat-memory case.
- Now both control_get and control_set:
  1. First read lower-memory byte 0x02 bit 7 (`Flat_mem`). Flat-memory modules immediately return `ONLP_STATUS_E_UNSUPPORTED` without touching the page select registers.
  2. For paged modules, check the TX Disable Supported advertising bit at page 01h byte 0x9B bit 1 before issuing the page 10h access. (`control_get` previously skipped this check entirely.)

## Test plan
- [x] Clean rebuild of `onlp-x86-64-accton-as9726-32d-r0` and resulting `libonlp-x86-64-accton-as9726-32d.so` contains the new log strings:
  - `Setting tx disable to port(%d) is not supported (flat-memory module)`
  - `Getting tx disable from port(%d) is not supported (flat-memory module)`
  - `Getting tx disable from port(%d) is not supported`
- [x] On-device verification via CPython driving `libonlp.onlp_sfp_control_get()`:
  - Unsupported / flat-memory module → returns `-10 (E_UNSUPPORTED)` (previously returned a stale/garbage byte with rc=0).
  - Paged QSFP-DD with TX disable advertised → returns lane mask as before.
  - QSFP+ and SFP paths unchanged and still work.