### PR TITLE
[Accton][as9726-32d] Check TX_DISABLE support before access in onlp_sfpi_control_get/set

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
@@ -63,6 +63,8 @@
 #define QSFP_DD_PAGE_ADMIN_INFO 0x0
 #define QSFP_DD_PAGE_ADVERTISING 0x1
 #define QSFP_DD_PAGE_LANE_CTRL 0x10
+#define QSFP_DD_LOWER_OFFSET_STATUS 0x02
+#define QSFP_DD_FLAT_MEM 0x80                          /* byte 0x02 bit 7 */
 #define QSFP_DD_P01H_OFFSET_CONTROL_1 0x9B
 #define QSFP_DD_P01H_TX_DISABLE_SUPPORT 0x2
 #define QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX 0x82
@@ -349,6 +351,12 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 				identifier = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_IDENTIFIER);
 				if (identifier == QSFP_DD_IDENTIFIER) {
+					/* Flat-memory CMIS modules do not implement page 01h/10h */
+					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS) & QSFP_DD_FLAT_MEM) {
+						AIM_LOG_ERROR("Setting tx disable to port(%d) is not supported (flat-memory module)\r\n", port);
+						rv = ONLP_STATUS_E_UNSUPPORTED;
+						break;
+					}
 					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADVERTISING);
 					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P01H_OFFSET_CONTROL_1) & QSFP_DD_P01H_TX_DISABLE_SUPPORT){
 
@@ -488,17 +496,31 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 				identifier = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_IDENTIFIER);
 				if (identifier == QSFP_DD_IDENTIFIER) {
-					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0);
-					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL);
-					tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX);
-					
+					/* Flat-memory CMIS modules do not implement page 01h/10h */
+					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS) & QSFP_DD_FLAT_MEM) {
+						AIM_LOG_ERROR("Getting tx disable from port(%d) is not supported (flat-memory module)\r\n", port);
+						rv = ONLP_STATUS_E_UNSUPPORTED;
+						break;
+					}
+					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADVERTISING);
+					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P01H_OFFSET_CONTROL_1) & QSFP_DD_P01H_TX_DISABLE_SUPPORT) {
+						onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0);
+						onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL);
+						tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX);
+						*value = tx_dis;
+
+						rv = ONLP_STATUS_OK;
+					} else {
+						AIM_LOG_ERROR("Getting tx disable from port(%d) is not supported\r\n", port);
+						rv = ONLP_STATUS_E_UNSUPPORTED;
+					}
 					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADMIN_INFO);
 				} else { /* QSFP */
 					tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS);
-				}
-				*value = tx_dis;
+					*value = tx_dis;
 
-				rv = ONLP_STATUS_OK;
+					rv = ONLP_STATUS_OK;
+				}
 			} else {
 				rv = ONLP_STATUS_E_INTERNAL;
 			}


### PR DESCRIPTION
## Summary
Mirror of #191 (against support_linux_6.1) on the support_linux_4.19 branch. The QSFP-DD code path in both control_set and control_get can produce wrong results on modules that do not implement TX disable:

- Flat-memory CMIS modules (typically passive DACs / simple AOCs) only have lower memory + page 00h. The page select register is silently discarded, so a request for page 01h/10h actually still reads page 00h vendor info, returning plausible-looking but meaningless bytes.
- `control_get` previously did not check the TX Disable Supported advertising bit at all; it walked straight to page 10h and read byte 0x82. `control_set` already checked the advertising bit but missed the flat-memory case.

Both paths now:
1. Read lower-memory byte 0x02 bit 7 (`Flat_mem`) first. Flat-memory CMIS modules return `ONLP_STATUS_E_UNSUPPORTED` immediately without touching the page select registers.
2. For paged modules, check the TX Disable Supported advertising bit on page 01h byte 0x9B bit 1 (`control_get` previously skipped this).
3. Always restore page select back to admin info (page 00h) at the end.