### PR TITLE
onlp: zero-initialize sff_eeprom_t in show_inventory__

### DIFF
--- a/packages/base/any/onlp/src/onlp/module/src/onlp_main.c
+++ b/packages/base/any/onlp/src/onlp/module/src/onlp_main.c
@@ -82,7 +82,7 @@ show_inventory__(aim_pvs_t* pvs, int database)
                 continue;
             }
 
-            sff_eeprom_t sff;
+            sff_eeprom_t sff = {0};
             char status_str[32] = {0};
 
             sff_eeprom_parse(&sff, data);


### PR DESCRIPTION
## Summary
`show_inventory__()` declares `sff_eeprom_t sff;` on the stack without initialization before calling `sff_eeprom_parse(&sff, data)`.

When a transceiver has a checksum error, `sff_eeprom_parse_standard__()` returns early (via `sff_eeprom_validate()`) **before** populating `sff.info`. The non-standard parse path (`sff_eeprom_parse_nonstandard__`) then runs `strncmp` on `sff.info.vendor`/`sff.info.model`, which still hold uninitialized stack data. As a result, a bad module can be misidentified or printed with garbage vendor/model/serial fields.

## Fix
Zero-initialize the struct at the call site (`sff_eeprom_t sff = {0};`) so that on parse failure the state is clean and `onlpdump` reports `UNK` instead of stale data.

Note: the root cause is in `sm/bigcode` (`sff_eeprom_parse()` assumes the caller pre-zeroes the struct, unlike `sff_eeprom_parse_file()` which memsets), but that submodule is upstream-maintained, so the fix is applied at the caller boundary.
