### PR TITLE
[Accton][as9726-32d] Route SFP errors to syslog, drop unsupported-state logs

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
@@ -23,6 +23,8 @@
  *
  *
  ***********************************************************/
+#include <syslog.h>
+
 #include <onlp/platformi/sfpi.h>
 #include <onlplib/i2c.h>
 #include <onlplib/file.h>
@@ -143,7 +145,7 @@ int onlp_sfpi_is_present(int port)
 
 		if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, bus, 
 					addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n"
+			syslog(LOG_ERR, "Unable to read present status from port(%d)"
 				      , port);
 			return ONLP_STATUS_E_INTERNAL;
 		}
@@ -153,7 +155,7 @@ int onlp_sfpi_is_present(int port)
 
 		if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, bus, 
 					addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n"
+			syslog(LOG_ERR, "Unable to read present status from port(%d)"
 				      , port);
 			return ONLP_STATUS_E_INTERNAL;
 		}
@@ -175,7 +177,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	sprintf(file, MODULE_PRESENT_ALL_ATTR, bus, addr);
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD2.");
+		syslog(LOG_ERR, "Unable to open the module_present_all device file of CPLD2.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -183,7 +185,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 2) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields the module_present_all device file of CPLD2.");
+		syslog(LOG_ERR, "Unable to read all fields the module_present_all device file of CPLD2.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -192,7 +194,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	sprintf(file, MODULE_PRESENT_ALL_ATTR, bus, addr);
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD3.");
+		syslog(LOG_ERR, "Unable to open the module_present_all device file of CPLD3.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -200,7 +202,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 3) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields the module_present_all device file of CPLD3.");
+		syslog(LOG_ERR, "Unable to read all fields the module_present_all device file of CPLD3.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -231,7 +233,7 @@ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 
 	fp = fopen(MODULE_RXLOS_ALL_ATTR_CPLD, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_rx_los_all device file of CPLD(0x%d)"
+		syslog(LOG_ERR, "Unable to open the module_rx_los_all device file of CPLD(0x%d)"
 			      , addr);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -241,7 +243,7 @@ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 5) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields from the module_rx_los_all device file of CPLD(0x%d)"
+		syslog(LOG_ERR, "Unable to read all fields from the module_rx_los_all device file of CPLD(0x%d)"
 			      , addr);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -277,12 +279,12 @@ int onlp_sfpi_eeprom_read(int port, uint8_t data[256])
 
 	if (onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT,
 			  onlp_sfpi_map_bus_index(port)) != ONLP_STATUS_OK) {
-		AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+		syslog(LOG_ERR, "Unable to read eeprom from port(%d)", port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
 	if (size != 256) {
-		AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", 
+		syslog(LOG_ERR, "Unable to read eeprom from port(%d), size is different!", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -299,14 +301,14 @@ int onlp_sfpi_dom_read(int port, uint8_t data[256])
 	sprintf(file, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port));
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the eeprom device file of port(%d)",
+		syslog(LOG_ERR, "Unable to open the eeprom device file of port(%d)",
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
 	if (fseek(fp, 256, SEEK_CUR) != 0) {
 		fclose(fp);
-		AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", 
+		syslog(LOG_ERR, "Unable to set the file position indicator of port(%d)", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -314,7 +316,7 @@ int onlp_sfpi_dom_read(int port, uint8_t data[256])
 	int ret = fread(data, 1, 256, fp);
 	fclose(fp);
 	if (ret != 256) {
-		AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", 
+		syslog(LOG_ERR, "Unable to read the module_eeprom device file of port(%d)", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -368,49 +370,47 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 		if (present == 1) {
 			if(port >= 0 && port <= 31) {
 				if ((identifier = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_IDENTIFIER)) < 0) {
-					AIM_LOG_ERROR("Failed to read Identifier, unable to write tx_disable status to port(%d)\r\n", port);
+					syslog(LOG_ERR, "Failed to read Identifier, unable to write tx_disable status to port(%d)", port);
 					return ONLP_STATUS_E_INTERNAL;
 				}
 
 				if (identifier == QSFP_DD_IDENTIFIER) {
 					/* Flat-memory CMIS modules do not implement page 01h/10h */
 					if ((status_byte = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS)) < 0) {
-						AIM_LOG_ERROR("Failed to read Status byte, unable to write tx_disable status to port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to read Status byte, unable to write tx_disable status to port(%d)", port);
 						return ONLP_STATUS_E_INTERNAL;
 					}
 					if (status_byte & QSFP_DD_FLAT_MEM) {
-						AIM_LOG_ERROR("Setting tx_disable to port(%d) is not supported (flat-memory module)\r\n", port);
 						return ONLP_STATUS_E_UNSUPPORTED;
 					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
-						AIM_LOG_ERROR("Failed to set Bank 0, unable to write tx_disable status to port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to set Bank 0, unable to write tx_disable status to port(%d)", port);
 						return ONLP_STATUS_E_INTERNAL;
 					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADVERTISING)) < 0) {
-						AIM_LOG_ERROR("Failed to switch to Advertising Page on port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to switch to Advertising Page on port(%d)", port);
 						goto restore;
 					}
 					if ((support_ctrls = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P01H_OFFSET_CONTROL_1)) < 0) {
-						AIM_LOG_ERROR("Failed to read Support Control on port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to read Support Control on port(%d)", port);
 						rv = support_ctrls;
 						goto restore;
 					}
 					if (support_ctrls & QSFP_DD_P01H_TX_DISABLE_SUPPORT) {
 						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
-							AIM_LOG_ERROR("Failed to set Bank 0 on port(%d)\r\n", port);
+							syslog(LOG_ERR, "Failed to set Bank 0 on port(%d)", port);
 							goto restore;
 						}
 						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL)) < 0) {
-							AIM_LOG_ERROR("Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)\r\n", 
+							syslog(LOG_ERR, "Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)", 
 										QSFP_DD_PAGE_LANE_CTRL, port);
 							goto restore;
 						}
 						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX, (value & 0xff))) < 0) {
-							AIM_LOG_ERROR("Failed to write tx_disable value(0x%02x) to Lane Control register on port(%d)\r\n", value, port);
+							syslog(LOG_ERR, "Failed to write tx_disable value(0x%02x) to Lane Control register on port(%d)", value, port);
 							goto restore;
 						}
 					} else {
-						AIM_LOG_ERROR("Setting tx_disable to port(%d) is not supported\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 						goto restore;
 					}
@@ -418,11 +418,11 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 				restore:
 					if ((onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT,
 															QSFP_DD_PAGE_ADMIN_INFO)) < 0) {
-						AIM_LOG_ERROR("Failed to restore Page Select to Admin Info on port(%d)!\r\n", port);
+						syslog(LOG_ERR, "Failed to restore Page Select to Admin Info on port(%d)!", port);
 					}
 
 					if (rv < 0) {
-						AIM_LOG_ERROR("Unable to write tx_disable status to port(%d)\r\n", port);
+						syslog(LOG_ERR, "Unable to write tx_disable status to port(%d)", port);
 						rv = (rv == ONLP_STATUS_E_UNSUPPORTED) ? rv : ONLP_STATUS_E_INTERNAL;
 					} else {
 						rv = ONLP_STATUS_OK;
@@ -430,7 +430,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 				} else { /* QSFP */
 					/* txdis valid bit(bit0-bit3), xxxx 1111 */
 					if (onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS, (value & 0xf)) < 0) {
-						AIM_LOG_ERROR("Unable to write tx_disable status to port(%d)\r\n", port);
+						syslog(LOG_ERR, "Unable to write tx_disable status to port(%d)", port);
 						rv = ONLP_STATUS_E_INTERNAL;
 					} else {
 						rv = ONLP_STATUS_OK;
@@ -440,7 +440,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 				addr = 62;
 				if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT,
 							bus, addr, (port + 1)) < 0) {
-					AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", 
+					syslog(LOG_ERR, "Unable to set tx_disable status to port(%d)", 
 							port);
 					rv = ONLP_STATUS_E_INTERNAL;
 				} else {
@@ -459,7 +459,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 		if (onlp_file_write_int(value, MODULE_RESET_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to set reset status to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to set reset status to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -474,7 +474,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 		if (onlp_file_write_int(value, MODULE_LPMODE_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to set lp mode to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to set lp mode to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -511,7 +511,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_RXLOS_FORMAT, 
 				       bus, addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read rx_loss status from port(%d)\r\n",
+			syslog(LOG_ERR, "Unable to read rx_loss status from port(%d)",
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -526,7 +526,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_TXFAULT_FORMAT,
 						bus, addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read tx_fault status from port(%d)\r\n",
+			syslog(LOG_ERR, "Unable to read tx_fault status from port(%d)",
 						port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -541,50 +541,48 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 		if (present == 1) {
 			if (port >= 0 && port <= 31) {
 				if ((identifier = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_IDENTIFIER)) < 0) {
-					AIM_LOG_ERROR("Failed to read Identifier, unable to read tx_disable status from port(%d)\r\n", port);
+					syslog(LOG_ERR, "Failed to read Identifier, unable to read tx_disable status from port(%d)", port);
 					return ONLP_STATUS_E_INTERNAL;
 				}
 
 				if (identifier == QSFP_DD_IDENTIFIER) {
 					/* Flat-memory CMIS modules do not implement page 01h/10h */
 					if ((status_byte = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS)) < 0) {
-						AIM_LOG_ERROR("Failed to read Status byte, unable to read tx_disable status from port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to read Status byte, unable to read tx_disable status from port(%d)", port);
 						return ONLP_STATUS_E_INTERNAL;
 					}
 					if (status_byte & QSFP_DD_FLAT_MEM) {
-						AIM_LOG_ERROR("Getting tx_disable from port(%d) is not supported (flat-memory module)\r\n", port);
 						return ONLP_STATUS_E_UNSUPPORTED;
 					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
-						AIM_LOG_ERROR("Failed to set Bank 0, unable to read tx_disable status from port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to set Bank 0, unable to read tx_disable status from port(%d)", port);
 						return ONLP_STATUS_E_INTERNAL;
 					}
 					if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADVERTISING)) < 0) {
-						AIM_LOG_ERROR("Failed to switch to Advertising Page on port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to switch to Advertising Page on port(%d)", port);
 						goto restore;
 					}
 					if ((support_ctrls = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P01H_OFFSET_CONTROL_1)) < 0) {
-						AIM_LOG_ERROR("Failed to read Support Control on port(%d)\r\n", port);
+						syslog(LOG_ERR, "Failed to read Support Control on port(%d)", port);
 						rv = support_ctrls;
 						goto restore;
 					}
 					if (support_ctrls & QSFP_DD_P01H_TX_DISABLE_SUPPORT) {
 						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_BANK_SELECT, 0)) < 0) {
-							AIM_LOG_ERROR("Failed to set Bank 0 on port(%d)\r\n", port);
+							syslog(LOG_ERR, "Failed to set Bank 0 on port(%d)", port);
 							goto restore;
 						}
 						if ((rv = onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_LANE_CTRL)) < 0) {
-							AIM_LOG_ERROR("Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)\r\n",
+							syslog(LOG_ERR, "Failed to switch to Lane Control Page (Page 0x%02x) on port(%d)",
 										QSFP_DD_PAGE_LANE_CTRL, port);
 							goto restore;
 						}
 						if ((tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_P10H_OFFSET_OUTPUT_DISABLE_TX)) < 0) {
-							AIM_LOG_ERROR("Failed to read TX_DISABLE value from Lane Control register on port(%d)\r\n", port);
+							syslog(LOG_ERR, "Failed to read TX_DISABLE value from Lane Control register on port(%d)", port);
 							rv = tx_dis;
 							goto restore;
 						}
 					} else {
-						AIM_LOG_ERROR("Getting tx_disable from port(%d) is not supported\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 						goto restore;
 					}
@@ -592,11 +590,11 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 				restore:
 					if ((onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT,
 															QSFP_DD_PAGE_ADMIN_INFO)) < 0) {
-						AIM_LOG_ERROR("Failed to restore Page Select to Admin Info on port(%d)!\r\n", port);
+						syslog(LOG_ERR, "Failed to restore Page Select to Admin Info on port(%d)!", port);
 					}
 
 					if (rv < 0) {
-						AIM_LOG_ERROR("Unable to get tx_disable status from port(%d)\r\n", port);
+						syslog(LOG_ERR, "Unable to get tx_disable status from port(%d)", port);
 						rv = (rv == ONLP_STATUS_E_UNSUPPORTED) ? rv : ONLP_STATUS_E_INTERNAL;
 					} else {
 						*value = (tx_dis & 0xff);
@@ -604,7 +602,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 					}
 				} else { /* QSFP */
 					if ((tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS)) < 0) {
-						AIM_LOG_ERROR("Unable to read tx_disable status from port(%d)\r\n", port);
+						syslog(LOG_ERR, "Unable to read tx_disable status from port(%d)", port);
 						rv = ONLP_STATUS_E_INTERNAL;
 					} else {
 						*value = (tx_dis & 0xf);
@@ -615,7 +613,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 				addr = 62;
 				if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT,
 							bus, addr, (port+1)) < 0) {
-					AIM_LOG_ERROR("Unable to read tx_disabled status from port(%d)\r\n", 
+					syslog(LOG_ERR, "Unable to read tx_disabled status from port(%d)", 
 							port);
 					rv = ONLP_STATUS_E_INTERNAL;
 				} else {
@@ -634,7 +632,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_RESET_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to get reset status to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to get reset status to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -649,7 +647,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_LPMODE_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to get lp mode to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to get lp mode to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {


### PR DESCRIPTION
## Summary
Follow-up to #191 after customer integration testing. Two changes to the SFP log behaviour in `sfpi.c`:

1. **Drop unsupported-state logs entirely** — \"tx_disable not supported\" / \"(flat-memory module)\" messages were already covered by the `ONLP_STATUS_E_UNSUPPORTED` return code; the extra log line just polluted `onlpd -S` output. Removed:
   - 3 lines added in #191 (flat-mem in set/get, advertising-not-supported in get)
   - 1 pre-existing line in `control_set` (\"Setting tx_disable to port(%d) is not supported\")
2. **Route remaining errors to syslog only** — the other `AIM_LOG_ERROR` calls in this file (I2C/sysfs/eeprom failures, page-switch failures, restore failures, etc., 43 in total) are switched to direct `syslog(LOG_ERR, ...)`. The AIM log handler in onlpd has `TO_STDOUT` set whenever stdout is a TTY, and its stdout branch ignores log level entirely — so simply lowering the level (e.g. `AIM_LOG_SYSLOG_NOTICE`) does **not** keep the message off interactive output. Bypassing AIM with direct `syslog()` does. Errors continue to land in syslog as LOG_DAEMON since `onlpd` already called `openlog(\"onlpd\", LOG_PID, LOG_DAEMON)` at startup.

Trailing \`\\\\r\\\\n\` is removed from each message because `syslog()` appends a newline itself.
