### PR TITLE
[Accton][as9726-32d] Route SFP errors to syslog, drop unsupported-state logs

### DIFF
--- a/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as9726-32d/onlp/builds/x86_64_accton_as9726_32d/module/src/sfpi.c
@@ -23,6 +23,8 @@
  *
  *
  ***********************************************************/
+#include <syslog.h>
+
 #include <onlp/platformi/sfpi.h>
 #include <onlplib/i2c.h>
 #include <onlplib/file.h>
@@ -126,7 +128,7 @@ int onlp_sfpi_is_present(int port)
 
 		if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, bus, 
 					addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n"
+			syslog(LOG_ERR, "Unable to read present status from port(%d)"
 				      , port);
 			return ONLP_STATUS_E_INTERNAL;
 		}
@@ -136,7 +138,7 @@ int onlp_sfpi_is_present(int port)
 
 		if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, bus, 
 					addr, (port+1)) < 0) {
-			AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n"
+			syslog(LOG_ERR, "Unable to read present status from port(%d)"
 				      , port);
 			return ONLP_STATUS_E_INTERNAL;
 		}
@@ -158,7 +160,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	sprintf(file, MODULE_PRESENT_ALL_ATTR, bus, addr);
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD2.");
+		syslog(LOG_ERR, "Unable to open the module_present_all device file of CPLD2.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -166,7 +168,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 2) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields the module_present_all device file of CPLD2.");
+		syslog(LOG_ERR, "Unable to read all fields the module_present_all device file of CPLD2.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -175,7 +177,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	sprintf(file, MODULE_PRESENT_ALL_ATTR, bus, addr);
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD3.");
+		syslog(LOG_ERR, "Unable to open the module_present_all device file of CPLD3.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -183,7 +185,7 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 3) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields the module_present_all device file of CPLD3.");
+		syslog(LOG_ERR, "Unable to read all fields the module_present_all device file of CPLD3.");
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
@@ -214,7 +216,7 @@ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 
 	fp = fopen(MODULE_RXLOS_ALL_ATTR_CPLD, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the module_rx_los_all device file of CPLD(0x%d)"
+		syslog(LOG_ERR, "Unable to open the module_rx_los_all device file of CPLD(0x%d)"
 			      , addr);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -224,7 +226,7 @@ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 	fclose(fp);
 	if (count != 5) {
 		/* Likely a CPLD read timeout. */
-		AIM_LOG_ERROR("Unable to read all fields from the module_rx_los_all device file of CPLD(0x%d)"
+		syslog(LOG_ERR, "Unable to read all fields from the module_rx_los_all device file of CPLD(0x%d)"
 			      , addr);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -260,12 +262,12 @@ int onlp_sfpi_eeprom_read(int port, uint8_t data[256])
 
 	if (onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT,
 			  onlp_sfpi_map_bus_index(port)) != ONLP_STATUS_OK) {
-		AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+		syslog(LOG_ERR, "Unable to read eeprom from port(%d)", port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
 	if (size != 256) {
-		AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", 
+		syslog(LOG_ERR, "Unable to read eeprom from port(%d), size is different!", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -281,14 +283,14 @@ int onlp_sfpi_dom_read(int port, uint8_t data[256])
 	sprintf(file, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port));
 	fp = fopen(file, "r");
 	if (fp == NULL) {
-		AIM_LOG_ERROR("Unable to open the eeprom device file of port(%d)",
+		syslog(LOG_ERR, "Unable to open the eeprom device file of port(%d)",
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
 
 	if (fseek(fp, 256, SEEK_CUR) != 0) {
 		fclose(fp);
-		AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", 
+		syslog(LOG_ERR, "Unable to set the file position indicator of port(%d)", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -296,7 +298,7 @@ int onlp_sfpi_dom_read(int port, uint8_t data[256])
 	int ret = fread(data, 1, 256, fp);
 	fclose(fp);
 	if (ret != 256) {
-		AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", 
+		syslog(LOG_ERR, "Unable to read the module_eeprom device file of port(%d)", 
 			      port);
 		return ONLP_STATUS_E_INTERNAL;
 	}
@@ -353,7 +355,6 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 				if (identifier == QSFP_DD_IDENTIFIER) {
 					/* Flat-memory CMIS modules do not implement page 01h/10h */
 					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS) & QSFP_DD_FLAT_MEM) {
-						AIM_LOG_ERROR("Setting tx disable to port(%d) is not supported (flat-memory module)\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 						break;
 					}
@@ -366,7 +367,6 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 						rv = ONLP_STATUS_OK;
 					} else {
-						AIM_LOG_ERROR("Setting tx disable to port(%d) is not supported\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 					}
 					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADMIN_INFO);
@@ -385,7 +385,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 			addr = 62;
 			if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT,
 						bus, addr, (port + 1)) < 0) {
-				AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", 
+				syslog(LOG_ERR, "Unable to set tx_disable status to port(%d)", 
 					      port);
 				rv = ONLP_STATUS_E_INTERNAL;
 			} else {
@@ -406,7 +406,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 		if (onlp_file_write_int(value, MODULE_RESET_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to set reset status to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to set reset status to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -426,7 +426,7 @@ int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 
 		if (onlp_file_write_int(value, MODULE_LPMODE_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to set lp mode to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to set lp mode to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -461,7 +461,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 			addr = 62;
 			if (onlp_file_read_int(value, MODULE_RXLOS_FORMAT, 
 					       bus, addr, (port+1)) < 0) {
-				AIM_LOG_ERROR("Unable to read rx_loss status from port(%d)\r\n",
+				syslog(LOG_ERR, "Unable to read rx_loss status from port(%d)",
 					      port);
 				rv = ONLP_STATUS_E_INTERNAL;
 			} else {
@@ -477,7 +477,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 			addr = 62;
 			if (onlp_file_read_int(value, MODULE_TXFAULT_FORMAT,
 					       bus, addr, (port+1)) < 0) {
-				AIM_LOG_ERROR("Unable to read tx_fault status from port(%d)\r\n",
+				syslog(LOG_ERR, "Unable to read tx_fault status from port(%d)",
 					      port);
 				rv = ONLP_STATUS_E_INTERNAL;
 			} else {
@@ -498,7 +498,6 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 				if (identifier == QSFP_DD_IDENTIFIER) {
 					/* Flat-memory CMIS modules do not implement page 01h/10h */
 					if (onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_DD_LOWER_OFFSET_STATUS) & QSFP_DD_FLAT_MEM) {
-						AIM_LOG_ERROR("Getting tx disable from port(%d) is not supported (flat-memory module)\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 						break;
 					}
@@ -511,7 +510,6 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 						rv = ONLP_STATUS_OK;
 					} else {
-						AIM_LOG_ERROR("Getting tx disable from port(%d) is not supported\r\n", port);
 						rv = ONLP_STATUS_E_UNSUPPORTED;
 					}
 					onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_PAGE_SELECT, QSFP_DD_PAGE_ADMIN_INFO);
@@ -528,7 +526,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 			addr = 62;
 			if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT,
 					       bus, addr, (port+1)) < 0) {
-				AIM_LOG_ERROR("Unable to read tx_disabled status from port(%d)\r\n", 
+				syslog(LOG_ERR, "Unable to read tx_disabled status from port(%d)", 
 					      port);
 				rv = ONLP_STATUS_E_INTERNAL;
 			} else {
@@ -549,7 +547,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_RESET_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to get reset status to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to get reset status to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {
@@ -569,7 +567,7 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
 		if (onlp_file_read_int(value, MODULE_LPMODE_FORMAT,
 					bus, addr, (port + 1)) < 0) {
-			AIM_LOG_ERROR("Unable to get lp mode to port(%d)\r\n", 
+			syslog(LOG_ERR, "Unable to get lp mode to port(%d)", 
 				      port);
 			rv = ONLP_STATUS_E_INTERNAL;
 		} else {


### PR DESCRIPTION
## Summary
Mirror of #197 on support_linux_4.19. Follow-up to #192 after customer integration testing. Two changes to the SFP log behaviour in `sfpi.c`:

1. **Drop unsupported-state logs entirely** — \"tx disable not supported\" / \"(flat-memory module)\" messages were already covered by the `ONLP_STATUS_E_UNSUPPORTED` return code; the extra log line just polluted `onlpd -S` output. Removed:
   - 3 lines added in #192 (flat-mem in set/get, advertising-not-supported in get)
   - 1 pre-existing line in `control_set` (\"Setting tx disable to port(%d) is not supported\")
2. **Route remaining errors to syslog only** — the other `AIM_LOG_ERROR` calls in this file (I2C/sysfs/eeprom failures, 21 in total) are switched to direct `syslog(LOG_ERR, ...)`. The AIM log handler in onlpd has `TO_STDOUT` set whenever stdout is a TTY, and its stdout branch ignores log level entirely — so simply lowering the level (e.g. `AIM_LOG_SYSLOG_NOTICE`) does **not** keep the message off interactive output. Bypassing AIM with direct `syslog()` does. Errors continue to land in syslog as LOG_DAEMON since `onlpd` already called `openlog(\"onlpd\", LOG_PID, LOG_DAEMON)` at startup.

Trailing \`\\\\r\\\\n\` is removed from each message because `syslog()` appends a newline itself.
