### PR TITLE
[AS5835-54X] Upgrade kernel to 6.12

### DIFF
--- a/packages/base/any/kernels/6.12-lts/patches/driver-i2c-bus-intel-ismt-add-delay-param.patch
+++ b/packages/base/any/kernels/6.12-lts/patches/driver-i2c-bus-intel-ismt-add-delay-param.patch
@@ -1,0 +1,57 @@
+Add 'delay' module param to the driver.
+
+From: Cumulus Networks <support@cumulusnetworks.com>
+
+This is needed on S6000 for safe PMBUS access.
+Without setting the 'delay', the ismt driver throws 'completion wait
+timed out' error message.
+---
+ drivers/i2c/busses/i2c-ismt.c |   13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-ismt.c b/drivers/i2c/busses/i2c-ismt.c
+index a35a27c32..b89fbb60d 100644
+--- a/drivers/i2c/busses/i2c-ismt.c
++++ b/drivers/i2c/busses/i2c-ismt.c
+@@ -66,6 +66,7 @@
+ #include <linux/i2c.h>
+ #include <linux/acpi.h>
+ #include <linux/interrupt.h>
++#include <linux/delay.h>
+
+ #include <linux/io-64-nonatomic-lo-hi.h>
+
+@@ -190,9 +191,12 @@ static const struct pci_device_id ismt_ids[] = {
+ MODULE_DEVICE_TABLE(pci, ismt_ids);
+
+ /* Bus speed control bits for slow debuggers - refer to the docs for usage */
+-static unsigned int bus_speed;
++static unsigned int bus_speed = 100;
++static unsigned int delay = 1000;
+ module_param(bus_speed, uint, S_IRUGO);
+-MODULE_PARM_DESC(bus_speed, "Bus Speed in kHz (0 = BIOS default)");
++MODULE_PARM_DESC(bus_speed, "Bus Speed in kHz (1000 by default)");
++module_param(delay, uint, S_IRUGO);
++MODULE_PARM_DESC(delay, "Delay in microsecs before access (1000 by default)");
+
+ /**
+  * __ismt_desc_dump() - dump the contents of a specific descriptor
+@@ -400,6 +404,9 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 	struct device *dev = &priv->pci_dev->dev;
+ 	u8 *dma_buffer = PTR_ALIGN(&priv->buffer[0], 16);
+
++	if (delay > 0)
++		udelay(delay);
++
+ 	desc = &priv->hw[priv->head];
+
+ 	/* Initialize the DMA buffer */
+@@ -759,7 +766,7 @@ static void ismt_hw_init(struct ismt_priv *priv)
+ 		bus_speed = 1000;
+ 		break;
+ 	}
+-	dev_dbg(dev, "SMBus clock is running at %d kHz\n", bus_speed);
++	dev_info(dev, "SMBus clock is running at %d kHz with delay %d us\n", bus_speed, delay);
+ }
+
+ /**

--- a/packages/base/any/kernels/6.12-lts/patches/series
+++ b/packages/base/any/kernels/6.12-lts/patches/series
@@ -1,0 +1,1 @@
+driver-i2c-bus-intel-ismt-add-delay-param.patch

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as5835-54x ARCH=amd64 KERNELS="onl-kernel-6.1-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as5835-54x ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-6.1-lts-x86-64-all:amd64
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as5835-54x

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-cpld.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-cpld.c
@@ -1004,9 +1004,9 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
 /*
  * I2C init/probing/exit functions
  */
-static int as5835_54x_cpld_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as5835_54x_cpld_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	struct as5835_54x_cpld_data *data;
 	int ret = -ENODEV;

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-fan.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-fan.c
@@ -428,8 +428,7 @@ static const struct hwmon_chip_info as5835_54x_fan_chip_info = {
     .info = as5835_54x_fan_info,
 };
 
-static int as5835_54x_fan_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static int as5835_54x_fan_probe(struct i2c_client *client)
 {
     struct as5835_54x_fan_data *data;
     int status;

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-leds.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-leds.c
@@ -310,15 +310,13 @@ static int accton_as5835_54x_led_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int accton_as5835_54x_led_remove(struct platform_device *pdev)
+static void accton_as5835_54x_led_remove(struct platform_device *pdev)
 {
 	int i;
-	
+
 	for (i = 0; i < ARRAY_SIZE(accton_as5835_54x_leds); i++) {
 		led_classdev_unregister(&accton_as5835_54x_leds[i]);
 	}
-
-	return 0;
 }
 
 static struct platform_driver accton_as5835_54x_led_driver = {

--- a/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-psu.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/modules/builds/src/x86-64-accton-as5835-54x-psu.c
@@ -171,9 +171,9 @@ static const struct hwmon_chip_info as5835_54x_psu_chip_info = {
     .info = as5835_54x_psu_info,
 };
 
-static int as5835_54x_psu_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+static int as5835_54x_psu_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
 	struct as5835_54x_psu_data *data;
 	int status;
 

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/fani.c
@@ -182,8 +182,19 @@ static int
 _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 {
 	int val = 0;
+	int power_good = 0;
 
 	info->status |= ONLP_FAN_STATUS_PRESENT;
+
+    /* When the parent PSU has no AC input the ym1401 PMBus stops
+     * responding, so direction / rpm reads would silently return 0.
+     * Surface that as PRESENT|FAILED instead of an all-zero entry.
+     */
+    if (psu_status_info_get(pid, "psu_power_good", &power_good) == ONLP_STATUS_OK &&
+        power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_FAN_STATUS_FAILED;
+        return ONLP_STATUS_OK;
+    }
 
     /* get fan direction
      */
@@ -199,7 +210,7 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
      */
     if (psu_ym1401_pmbus_info_get(pid, "psu_fan1_speed_rpm", &val) == ONLP_STATUS_OK) {
         info->rpm = val;
-	    info->percentage = (info->rpm * 100) / MAX_PSU_FAN_SPEED;	    
+	    info->percentage = (info->rpm * 100) / MAX_PSU_FAN_SPEED;
     }
 
     return ONLP_STATUS_OK;

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.h
@@ -54,6 +54,10 @@
 
 int psu_ym1401_pmbus_info_get(int id, char *node, int *value);
 int psu_ym1401_pmbus_info_set(int id, char *node, int value);
+int psu_status_info_get(int id, char *node, int *value);
+
+#define PSU_STATUS_PRESENT    1
+#define PSU_STATUS_POWER_GOOD 1
 
 enum onlp_thermal_id
 {

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/psui.c
@@ -27,9 +27,6 @@
 #include <onlp/platformi/psui.h>
 #include "platform_lib.h"
 
-#define PSU_STATUS_PRESENT    1
-#define PSU_STATUS_POWER_GOOD 1
-
 #define PSU_NODE_MAX_INT_LEN  8
 #define PSU_NODE_MAX_PATH_LEN 64
 
@@ -40,7 +37,7 @@
         }                                       \
     } while(0)
 
-static int 
+int
 psu_status_info_get(int id, char *node, int *value)
 {
     int ret = 0;
@@ -124,9 +121,10 @@ int
 onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 {
     int val   = 0;
+    int power_good = 0;
     int ret   = ONLP_STATUS_OK;
     int index = ONLP_OID_ID_GET(id);
-    psu_type_t psu_type; 
+    psu_type_t psu_type;
 
     VALIDATE(id);
 
@@ -144,19 +142,15 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     info->status |= ONLP_PSU_STATUS_PRESENT;
 
-
-    /* Get power good status */
-    if (psu_status_info_get(index, "psu_power_good", &val) != 0) {
+    /* Get power good status (do not set FAILED here; we resolve UNPLUGGED
+     * vs. FAILED at the end of the function so the child fan/thermal OIDs
+     * can still be linked when the PSU bay is just unpowered).
+     */
+    if (psu_status_info_get(index, "psu_power_good", &power_good) != 0) {
         printf("Unable to read PSU(%d) node(psu_power_good)\r\n", index);
     }
 
-    if (val != PSU_STATUS_POWER_GOOD) {
-        info->status |=  ONLP_PSU_STATUS_FAILED;
-    }
-
-
-    /* Get PSU type
-     */
+    /* Get PSU type */
     psu_type = get_psu_type(index, info->model, sizeof(info->model));
 
     switch (psu_type) {
@@ -166,14 +160,24 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         case PSU_TYPE_DC_B2F:
             ret = psu_ym1401_info_get(info, IS_DC_INPUT(psu_type));
             break;
-        case PSU_TYPE_UNKNOWN:  /* User insert a unknown PSU or unplugged.*/
-            info->status |= ONLP_PSU_STATUS_UNPLUGGED;
-            info->status &= ~ONLP_PSU_STATUS_FAILED;
+        case PSU_TYPE_UNKNOWN:
+            /* User inserted an unknown PSU or PSU is unplugged. Link the
+             * child fan and thermal OIDs so they still show in onlpdump
+             * even when this PSU bay reports no power.
+             */
+            info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
+            info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
             ret = ONLP_STATUS_OK;
             break;
         default:
             ret = ONLP_STATUS_E_UNSUPPORTED;
             break;
+    }
+
+    if (power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_PSU_STATUS_UNPLUGGED;
+        info->status &= ~ONLP_PSU_STATUS_FAILED;
+        info->caps = 0;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/thermali.c
@@ -209,15 +209,16 @@ int
 onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int   tid;
+    int   psu_id;
+    int   power_good = 0;
     VALIDATE(id);
     int coretemp_max = 0, coretemp_temp = 0;
 
     tid = ONLP_OID_ID_GET(id);
 
-    /* Set the onlp_oid_hdr_t and capabilities */		
+    /* Set the onlp_oid_hdr_t and capabilities */
     *info = linfo[tid];
 
-    *info = linfo[tid];
     if(tid == THERMAL_CPU_CORE) {
         for (size_t i = 0; i < sysfs_count; i++) {
             if (onlp_file_read_int(&coretemp_temp, temp_entries[i].name) < 0) {
@@ -233,6 +234,19 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
         return ONLP_STATUS_OK;
     }
 
-    return onlp_file_read_int(&info->mcelsius, devfiles__[tid]);							
+    /* PSU-attached thermal: if the parent PSU has no power, the ym1401
+     * PMBus sensor won't respond. Mark FAILED so a 0 mcelsius reading
+     * isn't misread as an actual temperature.
+     */
+    if (tid == THERMAL_1_ON_PSU1 || tid == THERMAL_1_ON_PSU2) {
+        psu_id = (tid == THERMAL_1_ON_PSU1) ? PSU1_ID : PSU2_ID;
+        if (psu_status_info_get(psu_id, "psu_power_good", &power_good) == ONLP_STATUS_OK &&
+            power_good != PSU_STATUS_POWER_GOOD) {
+            info->status |= ONLP_THERMAL_STATUS_FAILED;
+            return ONLP_STATUS_OK;
+        }
+    }
+
+    return onlp_file_read_int(&info->mcelsius, devfiles__[tid]);
 }
 

--- a/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/lib/x86-64-accton-as5835-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/lib/x86-64-accton-as5835-54x-r0.yml
@@ -18,12 +18,13 @@ x86-64-accton-as5835-54x-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-6-1
+      <<: *kernel-6-12
 
     args: >-
       nopat
       console=ttyS0,115200n8
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/python/x86_64_accton_as5835_54x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/python/x86_64_accton_as5835_54x_r0/__init__.py
@@ -64,6 +64,8 @@ class OnlPlatform_x86_64_accton_as5835_54x_r0(OnlPlatformAccton,
                 ]
             )
 
+        subprocess.call('echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state > /dev/null', shell=True)
+
         # initialize SFP devices
         for port in range(1, 49):
             self.new_i2c_device('optoe2', 0x50, port+41)
@@ -73,7 +75,7 @@ class OnlPlatform_x86_64_accton_as5835_54x_r0(OnlPlatformAccton,
 
         # initialize QSFP devices
         for port in range(49, 55):
-            self.new_i2c_device('optoe1', 0x50, port-23)	
+            self.new_i2c_device('optoe1', 0x50, port-23)
             subprocess.call('echo 0 > /sys/bus/i2c/devices/3-0062/module_reset_%d' % port, shell=True)
 
         sfp_map = [28,29,26,30,31,27]
@@ -81,9 +83,9 @@ class OnlPlatform_x86_64_accton_as5835_54x_r0(OnlPlatformAccton,
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (i+49, sfp_map[i]), shell=True)
 
         #Set disable tx_disable to sfp port
-        for port in range(1, 39):       
+        for port in range(1, 39):
             subprocess.call('echo 0 > /sys/bus/i2c/devices/3-0061/module_tx_disable_%d' % port, shell=True)
-        for port in range(39, 49): 
+        for port in range(39, 49):
             subprocess.call('echo 0 > /sys/bus/i2c/devices/3-0062/module_tx_disable_%d' % port, shell=True)
 
         return True


### PR DESCRIPTION
## Summary

Upgrades AS5835-54X platform from kernel 6.1 to 6.12 LTS, plus the matching base-kernel patch needed for the iSMT SMBus controller on this board.

### Per-platform driver changes
- `modules/PKG.yml`, `modules/builds/Makefile`: switch `KERNELS` to `onl-kernel-6.12-lts-x86-64-all`
- `platform-config/r0/.../x86-64-accton-as5835-54x-r0.yml`: kernel anchor `*kernel-6-1` → `*kernel-6-12`
- `cpld.c`, `psu.c`, `fan.c`: `i2c_driver.probe()` single-arg signature; restore the device id via `i2c_client_get_device_id()` in `cpld.c` and `psu.c` where the body still consumes it
- `leds.c`: `platform_driver.remove()` returns `void` per kernel 6.11+ API

### Base kernel patch ported from 6.1-lts
- `packages/base/any/kernels/6.12-lts/patches/{series, driver-i2c-bus-intel-ismt-add-delay-param.patch}`: port the iSMT delay/bus_speed module-param patch from 6.1-lts. Sets `bus_speed=100 kHz`, adds `udelay(1000)` before each xfer for safe PMBUS access. Without it ismt prints `completion wait timed out` during early init.

### Platform-config tweaks aligned with SONiC
- `r0.yml` args: add `pcie_aspm=off` so the iSMT PCIe link is not parked in L1 (SONiC has the same arg for the same reason)
- `__init__.py`: after instantiating the pca9548 tree, set every mux's `idle_state=-2 (MUX_IDLE_AS_IS)` so iSMT is not hammered with deselect cycles on every i2c xfer 
