### PR TITLE
[AS5812-54X] Upgrade kernel from 4.14 to 6.12

### DIFF
--- a/packages/base/any/kernels/modules/cpr_4011_4mxx.c
+++ b/packages/base/any/kernels/modules/cpr_4011_4mxx.c
@@ -216,6 +216,27 @@ static const struct attribute_group cpr_4011_4mxx_group = {
 };
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+static umode_t cpr_4011_4mxx_is_visible(const void *drvdata,
+                  enum hwmon_sensor_types type,
+                  u32 attr, int channel)
+{
+    return 0;
+}
+
+static const struct hwmon_channel_info *cpr_4011_4mxx_info[] = {
+    HWMON_CHANNEL_INFO(power, HWMON_P_ENABLE),
+    NULL,
+};
+
+static const struct hwmon_ops cpr_4011_4mxx_hwmon_ops = {
+    .is_visible = cpr_4011_4mxx_is_visible,
+};
+
+static const struct hwmon_chip_info cpr_4011_4mxx_chip_info = {
+    .ops = &cpr_4011_4mxx_hwmon_ops,
+    .info = cpr_4011_4mxx_info,
+};
+
 static int cpr_4011_4mxx_probe(struct i2c_client *client)
 #else
 static int cpr_4011_4mxx_probe(struct i2c_client *client,
@@ -249,7 +270,10 @@ static int cpr_4011_4mxx_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+    data->hwmon_dev = hwmon_device_register_with_info(&client->dev, "cpr_4011_4mxx",
+                                                      NULL, &cpr_4011_4mxx_chip_info, NULL);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
     data->hwmon_dev = hwmon_device_register_with_info(&client->dev, "cpr_4011_4mxx",
                                                       NULL, NULL, NULL);
 #else

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as5812-54x ARCH=amd64 KERNELS="onl-kernel-4.14-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as5812-54x ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/Makefile
@@ -1,5 +1,5 @@
-KERNELS := onl-kernel-4.14-lts-x86-64-all:amd64
-KMODULES := $(wildcard *.c)
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
+KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as5812-54x
 ARCH := x86_64

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/Makefile
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/Makefile
@@ -1,0 +1,4 @@
+obj-m += x86-64-accton-as5812-54x-cpld.o
+obj-m += x86-64-accton-as5812-54x-fan.o
+obj-m += x86-64-accton-as5812-54x-leds.o
+obj-m += x86-64-accton-as5812-54x-psu.o

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-cpld.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-cpld.c
@@ -1081,11 +1081,11 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
 /*
  * I2C init/probing/exit functions
  */
-static int as5812_54x_cpld_mux_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static int as5812_54x_cpld_mux_probe(struct i2c_client *client)
 {
+	const struct i2c_device_id *id = i2c_client_get_device_id(client);
     struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
-	int num, force, class;
+	int num, force;
 	struct i2c_mux_core *muxc;
 	struct as5812_54x_cpld_data *data;
     int ret = 0;
@@ -1110,9 +1110,8 @@ static int as5812_54x_cpld_mux_probe(struct i2c_client *client,
 	/* Now create an adapter for each channel */
 	for (num = 0; num < chips[data->type].nchans; num++) {
 		force = 0;			  /* dynamic adap number */
-		class = 0;			  /* no class by default */
 
-		ret = i2c_mux_add_adapter(muxc, force, num, class);
+		ret = i2c_mux_add_adapter(muxc, force, num);
 
 		if (ret) {
 			dev_err(&client->dev,
@@ -1166,7 +1165,7 @@ add_mux_failed:
 	return ret;
 }
 
-static int as5812_54x_cpld_mux_remove(struct i2c_client *client)
+static void as5812_54x_cpld_mux_remove(struct i2c_client *client)
 {
     struct i2c_mux_core *muxc = i2c_get_clientdata(client);
     struct as5812_54x_cpld_data *data = i2c_mux_priv(muxc);
@@ -1194,8 +1193,6 @@ static int as5812_54x_cpld_mux_remove(struct i2c_client *client)
     }
 
 	i2c_mux_del_adapters(muxc);
-
-    return 0;
 }
 
 static int as5812_54x_cpld_read_internal(struct i2c_client *client, u8 reg)

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-fan.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-fan.c
@@ -260,6 +260,27 @@ static const struct attribute_group accton_as5812_54x_fan_group = {
     .attrs = accton_as5812_54x_fan_attributes,
 };
 
+static umode_t accton_as5812_54x_fan_is_visible(const void *drvdata,
+                  enum hwmon_sensor_types type,
+                  u32 attr, int channel)
+{
+    return 0;
+}
+
+static const struct hwmon_channel_info *accton_as5812_54x_fan_info[] = {
+    HWMON_CHANNEL_INFO(fan, HWMON_F_INPUT),
+    NULL,
+};
+
+static const struct hwmon_ops accton_as5812_54x_fan_hwmon_ops = {
+    .is_visible = accton_as5812_54x_fan_is_visible,
+};
+
+static const struct hwmon_chip_info accton_as5812_54x_fan_chip_info = {
+    .ops = &accton_as5812_54x_fan_hwmon_ops,
+    .info = accton_as5812_54x_fan_info,
+};
+
 static int accton_as5812_54x_fan_read_value(u8 reg)
 {
     return as5812_54x_cpld_read(0x60, reg);
@@ -355,7 +376,7 @@ static int accton_as5812_54x_fan_probe(struct platform_device *pdev)
     }
 
     fan_data->hwmon_dev = hwmon_device_register_with_info(&pdev->dev, "as5812_54x_fan",
-                                                      NULL, NULL, NULL);
+                                                      NULL, &accton_as5812_54x_fan_chip_info, NULL);
 	if (IS_ERR(fan_data->hwmon_dev)) {
 		status = PTR_ERR(fan_data->hwmon_dev);
 		goto exit_remove;

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-fan.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-fan.c
@@ -371,12 +371,10 @@ exit:
     return status;
 }
 
-static int accton_as5812_54x_fan_remove(struct platform_device *pdev)
+static void accton_as5812_54x_fan_remove(struct platform_device *pdev)
 {
     hwmon_device_unregister(fan_data->hwmon_dev);
     sysfs_remove_group(&fan_data->pdev->dev.kobj, &accton_as5812_54x_fan_group);
-
-    return 0;
 }
 
 #define DRVNAME "as5812_54x_fan"

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-leds.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-leds.c
@@ -521,15 +521,13 @@ static int accton_as5812_54x_led_probe(struct platform_device *pdev)
     return ret;
 }
 
-static int accton_as5812_54x_led_remove(struct platform_device *pdev)
+static void accton_as5812_54x_led_remove(struct platform_device *pdev)
 {
     int i;
 
     for (i = 0; i < ARRAY_SIZE(accton_as5812_54x_leds); i++) {
         led_classdev_unregister(&accton_as5812_54x_leds[i]);
     }
-
-    return 0;
 }
 
 static struct platform_driver accton_as5812_54x_led_driver = {

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-psu.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-psu.c
@@ -197,6 +197,27 @@ static const struct attribute_group as5812_54x_psu_group = {
     .attrs = as5812_54x_psu_attributes,
 };
 
+static umode_t as5812_54x_psu_is_visible(const void *drvdata,
+                  enum hwmon_sensor_types type,
+                  u32 attr, int channel)
+{
+    return 0;
+}
+
+static const struct hwmon_channel_info *as5812_54x_psu_info[] = {
+    HWMON_CHANNEL_INFO(power, HWMON_P_ENABLE),
+    NULL,
+};
+
+static const struct hwmon_ops as5812_54x_psu_hwmon_ops = {
+    .is_visible = as5812_54x_psu_is_visible,
+};
+
+static const struct hwmon_chip_info as5812_54x_psu_chip_info = {
+    .ops = &as5812_54x_psu_hwmon_ops,
+    .info = as5812_54x_psu_info,
+};
+
 static int as5812_54x_psu_probe(struct i2c_client *client)
 {
     const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
@@ -228,7 +249,7 @@ static int as5812_54x_psu_probe(struct i2c_client *client)
     }
 
     data->hwmon_dev = hwmon_device_register_with_info(&client->dev, "as5812_54x_psu",
-                                                      NULL, NULL, NULL);
+                                                      NULL, &as5812_54x_psu_chip_info, NULL);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         goto exit_remove;

--- a/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-psu.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/modules/builds/src/x86-64-accton-as5812-54x-psu.c
@@ -197,9 +197,9 @@ static const struct attribute_group as5812_54x_psu_group = {
     .attrs = as5812_54x_psu_attributes,
 };
 
-static int as5812_54x_psu_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static int as5812_54x_psu_probe(struct i2c_client *client)
 {
+    const struct i2c_device_id *dev_id = i2c_client_get_device_id(client);
     struct as5812_54x_psu_data *data;
     int status;
 
@@ -248,15 +248,13 @@ exit:
     return status;
 }
 
-static int as5812_54x_psu_remove(struct i2c_client *client)
+static void as5812_54x_psu_remove(struct i2c_client *client)
 {
     struct as5812_54x_psu_data *data = i2c_get_clientdata(client);
 
     hwmon_device_unregister(data->hwmon_dev);
     sysfs_remove_group(&client->dev.kobj, &as5812_54x_psu_group);
     kfree(data);
-
-    return 0;
 }
 
 enum psu_index 

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/fani.c
@@ -222,6 +222,7 @@ static int
 _onlp_fani_info_get_fan_on_psu(int local_id, onlp_fan_info_t* info)
 {
     int   psu_id;
+    int   power_good = 0;
     int   fd, len, nbytes = 10;
     char  r_data[10]   = {0};
     char  fullpath[PATH_MAX] = {0};
@@ -231,6 +232,17 @@ _onlp_fani_info_get_fan_on_psu(int local_id, onlp_fan_info_t* info)
      */
     psu_id    = (local_id-FAN_1_ON_PSU1) + 1;
     DEBUG_PRINT("[psu_id: %d]", psu_id);
+
+    /* When the PSU has no AC input the cpr_4011 / ym2401 PMBus does not
+     * respond, so model name reads back empty and get_psu_type() returns
+     * UNKNOWN. Surface the fan slot as PRESENT|FAILED in that case so it
+     * doesn't quietly come back as an all-zero "status: 0x0" entry.
+     */
+    if (psu_status_info_get(psu_id, 1, "psu_power_good", &power_good) == 0 &&
+        power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_FAN_STATUS_PRESENT | ONLP_FAN_STATUS_FAILED;
+        return ONLP_STATUS_OK;
+    }
 
     psu_type  = get_psu_type(psu_id, NULL, 0); /* psu_id = 1 , present PSU1. pus_id =2 , present PSU2 */
     DEBUG_PRINT("[psu_type: %d]", psu_type);

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.c
@@ -293,3 +293,24 @@ int psu_serial_number_get(int id, psu_type_t psu_type, char *serial, int serial_
     serial[PSU_SERIAL_NUMBER_LEN] = '\0';
     return ONLP_STATUS_OK;
 }
+
+#define CPLD_BUS_SCAN_MAX 16
+
+int as5812_54x_cpld_bus(void)
+{
+    static int resolved = -1;
+    char probe[64];
+    int b;
+
+    if (resolved >= 0) return resolved;
+
+    for (b = 0; b < CPLD_BUS_SCAN_MAX; b++) {
+        snprintf(probe, sizeof(probe),
+                 "/sys/bus/i2c/devices/%d-0060/version", b);
+        if (access(probe, R_OK) == 0) {
+            resolved = b;
+            return b;
+        }
+    }
+    return -1;
+}

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
@@ -77,6 +77,16 @@ int psu_status_info_get(int id, int is_ac, char *node, int *value);
 int psu_ym2401_pmbus_info_get(int id, char *node, int *value);
 int psu_ym2401_pmbus_info_set(int id, char *node, int value);
 
+/*
+ * Resolve the i2c bus number that hosts the three CPLDs (0x60/0x61/0x62).
+ * AS5812 wires the CPLDs to the i801 SMBus controller, whose i2c index
+ * shifts between kernels: 4.14 enumerated i801 as i2c-0, 6.12 lands iSMT
+ * first and pushes i801 to i2c-1. The result is cached after the first
+ * successful resolution. Returns -1 if no CPLD at 0x60 is found on any
+ * bus 0..15. Not thread-safe; the first caller initialises the cache.
+ */
+int as5812_54x_cpld_bus(void);
+
 #define PSU_STATUS_PRESENT    1
 #define PSU_STATUS_POWER_GOOD 1
 

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
@@ -54,7 +54,8 @@
 #define PSU1_AC_3YPOWER_EEPROM_NODE(node) PSU1_AC_3YPOWER_EEPROM_PREFIX#node
 #define PSU2_AC_3YPOWER_EEPROM_NODE(node) PSU2_AC_3YPOWER_EEPROM_PREFIX#node
 
-#define IDPROM_PATH "/sys/bus/i2c/devices/1-0057/eeprom"
+#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0057/eeprom"
+#define IDPROM_PATH_2 "/sys/bus/i2c/devices/1-0057/eeprom"
 
 int deviceNodeWriteInt(char *filename, int value, int data_len);
 int deviceNodeReadBinary(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
@@ -73,8 +73,12 @@ typedef enum psu_type {
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
 int psu_serial_number_get(int id, psu_type_t psu_type, char *serial, int serial_len);
+int psu_status_info_get(int id, int is_ac, char *node, int *value);
 int psu_ym2401_pmbus_info_get(int id, char *node, int *value);
 int psu_ym2401_pmbus_info_set(int id, char *node, int value);
+
+#define PSU_STATUS_PRESENT    1
+#define PSU_STATUS_POWER_GOOD 1
 
 #define DEBUG_MODE 0
 

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/platform_lib.h
@@ -54,7 +54,7 @@
 #define PSU1_AC_3YPOWER_EEPROM_NODE(node) PSU1_AC_3YPOWER_EEPROM_PREFIX#node
 #define PSU2_AC_3YPOWER_EEPROM_NODE(node) PSU2_AC_3YPOWER_EEPROM_PREFIX#node
 
-#define IDPROM_PATH "/sys/devices/pci0000:00/0000:00:13.0/i2c-1/1-0057/eeprom"
+#define IDPROM_PATH "/sys/bus/i2c/devices/1-0057/eeprom"
 
 int deviceNodeWriteInt(char *filename, int value, int data_len);
 int deviceNodeReadBinary(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/psui.c
@@ -103,10 +103,6 @@ psu_cpr_4011_info_get(onlp_psu_info_t* info)
     /* Set capability
      */
     info->caps = ONLP_PSU_CAPS_AC;
-    
-	if (info->status & ONLP_PSU_STATUS_FAILED) {
-	    return ONLP_STATUS_OK;
-	}
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
@@ -155,10 +151,6 @@ psu_um400d_info_get(onlp_psu_info_t* info)
      */
     info->caps = ONLP_PSU_CAPS_DC48;
 
-    if (info->status & ONLP_PSU_STATUS_FAILED) {
-        return ONLP_STATUS_OK;
-    }
-
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
 
@@ -174,10 +166,6 @@ psu_ym2401_info_get(onlp_psu_info_t* info)
     /* Set capability
      */
     info->caps = ONLP_PSU_CAPS_AC;
-    
-    if (info->status & ONLP_PSU_STATUS_FAILED) {
-        return ONLP_STATUS_OK;
-    }
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/psui.c
@@ -28,9 +28,6 @@
 #include <string.h>
 #include "platform_lib.h"
 
-#define PSU_STATUS_PRESENT    1
-#define PSU_STATUS_POWER_GOOD 1
-
 #define PSU_NODE_MAX_INT_LEN  8
 #define PSU_NODE_MAX_PATH_LEN 64
 
@@ -41,7 +38,7 @@
         }                                       \
     } while(0)
 
-static int 
+int
 psu_status_info_get(int id, int is_ac, char *node, int *value)
 {
     int ret = 0;
@@ -223,9 +220,10 @@ int
 onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 {
     int val   = 0;
+    int power_good = 0;
     int   ret = ONLP_STATUS_OK;
     int index = ONLP_OID_ID_GET(id);
-    psu_type_t psu_type; 
+    psu_type_t psu_type;
 
     VALIDATE(id);
 
@@ -242,21 +240,16 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         return ONLP_STATUS_OK;
     }
     info->status |= ONLP_PSU_STATUS_PRESENT;
-    
 
-    /* Get power good status */
-    if (psu_status_info_get(index, 1, "psu_power_good", &val) != 0) {
+    /* Get power good status (do not early-return on no-power: the PSU bay
+     * is still physically present and we want the caller to see UNPLUGGED
+     * rather than FAILED, plus keep the child fan/thermal OIDs linked).
+     */
+    if (psu_status_info_get(index, 1, "psu_power_good", &power_good) != 0) {
         printf("Unable to read PSU(%d) node(psu_power_good)\r\n", index);
     }
 
-    if (val != PSU_STATUS_POWER_GOOD) {
-        info->status |=  ONLP_PSU_STATUS_FAILED;
-        return 0;
-    }
-
-
-    /* Get PSU type
-     */
+    /* Get PSU type */
     psu_type = get_psu_type(index, info->model, sizeof(info->model));
 
     switch (psu_type) {
@@ -272,11 +265,25 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         case PSU_TYPE_DC_48V_B2F:
             ret = psu_um400d_info_get(info);
             break;
+        case PSU_TYPE_UNKNOWN:
+            /* Power off / EEPROM unreadable. Still link the child fan and
+             * thermal OIDs so they remain visible in onlpdump output.
+             */
+            info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
+            info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
+            ret = ONLP_STATUS_OK;
+            break;
         default:
             ret = ONLP_STATUS_E_UNSUPPORTED;
             break;
     }
     psu_serial_number_get(index, psu_type, info->serial, sizeof(info->serial));
+
+    if (power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_PSU_STATUS_UNPLUGGED;
+        info->status &= ~ONLP_PSU_STATUS_FAILED;
+        info->caps = 0;
+    }
 
     return ret;
 }

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sfpi.c
@@ -26,9 +26,9 @@
 #include <onlp/platformi/sfpi.h>
 #include <onlplib/i2c.h>
 #include <onlplib/file.h>
-#include <unistd.h>
 #include "x86_64_accton_as5812_54x_int.h"
 #include "x86_64_accton_as5812_54x_log.h"
+#include "platform_lib.h"
 
 #define SFP_PORT_MIN 0
 #define SFP_PORT_MAX 47
@@ -58,33 +58,6 @@
 #define CPLD_MUX_BUS_START_INDEX 2
 
 #define PORT_EEPROM_FORMAT              "/sys/bus/i2c/devices/%d-0050/eeprom"
-
-/*
- * The CPLDs are wired to the i801 SMBus controller; its i2c bus number
- * shifts between kernels (4.14: i2c-0, 6.12: i2c-1). Resolve once by
- * scanning sysfs for the CPLD at 0x60, cache, and use that bus index in
- * the per-CPLD sysfs path formats.
- */
-#define CPLD_BUS_SCAN_MAX 16
-
-static int cpld_bus(void)
-{
-    static int resolved = -1;
-    char probe[64];
-    int b;
-
-    if (resolved >= 0) return resolved;
-
-    for (b = 0; b < CPLD_BUS_SCAN_MAX; b++) {
-        snprintf(probe, sizeof(probe),
-                 "/sys/bus/i2c/devices/%d-0060/version", b);
-        if (access(probe, R_OK) == 0) {
-            resolved = b;
-            return b;
-        }
-    }
-    return -1;
-}
 
 #define MODULE_PRESENT_FORMAT		    "/sys/bus/i2c/devices/%d-00%d/module_present_%d"
 #define MODULE_RXLOS_FORMAT             "/sys/bus/i2c/devices/%d-00%d/module_rx_los_%d"
@@ -260,7 +233,7 @@ onlp_sfpi_is_present(int port)
      */
     int present;
     int addr = (port < 24) ? 61 : 62;
-    int bus = cpld_bus();
+    int bus = as5812_54x_cpld_bus();
 
     if (bus < 0) {
         AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
@@ -280,7 +253,7 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
     uint32_t bytes[7];
     FILE* fp;
     char path[64];
-    int bus = cpld_bus();
+    int bus = as5812_54x_cpld_bus();
 
     if (bus < 0) {
         AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
@@ -348,7 +321,7 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
     uint32_t *ptr = bytes;
     FILE* fp;
     char path[64];
-    int bus = cpld_bus();
+    int bus = as5812_54x_cpld_bus();
 
     /* Read present status of port 0~23 */
     int addr, i = 0;
@@ -488,7 +461,7 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
     VALIDATE_PORT(port);
 
     int addr = (port < 24) ? 61 : 62;
-    int bus = cpld_bus();
+    int bus = as5812_54x_cpld_bus();
 
     if (bus < 0) {
         AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
@@ -575,7 +548,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
     VALIDATE_PORT(port);
 
     int addr = (port < 24) ? 61 : 62;
-    int bus = cpld_bus();
+    int bus = as5812_54x_cpld_bus();
 
     if (bus < 0) {
         AIM_LOG_ERROR("Unable to locate CPLD i2c bus");

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sfpi.c
@@ -26,6 +26,7 @@
 #include <onlp/platformi/sfpi.h>
 #include <onlplib/i2c.h>
 #include <onlplib/file.h>
+#include <unistd.h>
 #include "x86_64_accton_as5812_54x_int.h"
 #include "x86_64_accton_as5812_54x_log.h"
 
@@ -57,16 +58,42 @@
 #define CPLD_MUX_BUS_START_INDEX 2
 
 #define PORT_EEPROM_FORMAT              "/sys/bus/i2c/devices/%d-0050/eeprom"
-#define MODULE_PRESENT_FORMAT		    "/sys/bus/i2c/devices/0-00%d/module_present_%d"
-#define MODULE_RXLOS_FORMAT             "/sys/bus/i2c/devices/0-00%d/module_rx_los_%d"
-#define MODULE_TXFAULT_FORMAT           "/sys/bus/i2c/devices/0-00%d/module_tx_fault_%d"
-#define MODULE_TXDISABLE_FORMAT         "/sys/bus/i2c/devices/0-00%d/module_tx_disable_%d"
-#define MODULE_RESET_FORMAT             "/sys/bus/i2c/devices/0-00%d/module_reset_%d"
-#define MODULE_LPMODE_FORMAT            "/sys/bus/i2c/devices/0-00%d/module_lpmode_%d"
-#define MODULE_PRESENT_ALL_ATTR_CPLD2	"/sys/bus/i2c/devices/0-0061/module_present_all"
-#define MODULE_PRESENT_ALL_ATTR_CPLD3	"/sys/bus/i2c/devices/0-0062/module_present_all"
-#define MODULE_RXLOS_ALL_ATTR_CPLD2	    "/sys/bus/i2c/devices/0-0061/module_rx_los_all"
-#define MODULE_RXLOS_ALL_ATTR_CPLD3	    "/sys/bus/i2c/devices/0-0062/module_rx_los_all"
+
+/*
+ * The CPLDs are wired to the i801 SMBus controller; its i2c bus number
+ * shifts between kernels (4.14: i2c-0, 6.12: i2c-1). Resolve once by
+ * scanning sysfs for the CPLD at 0x60, cache, and use that bus index in
+ * the per-CPLD sysfs path formats.
+ */
+#define CPLD_BUS_SCAN_MAX 16
+
+static int cpld_bus(void)
+{
+    static int resolved = -1;
+    char probe[64];
+    int b;
+
+    if (resolved >= 0) return resolved;
+
+    for (b = 0; b < CPLD_BUS_SCAN_MAX; b++) {
+        snprintf(probe, sizeof(probe),
+                 "/sys/bus/i2c/devices/%d-0060/version", b);
+        if (access(probe, R_OK) == 0) {
+            resolved = b;
+            return b;
+        }
+    }
+    return -1;
+}
+
+#define MODULE_PRESENT_FORMAT		    "/sys/bus/i2c/devices/%d-00%d/module_present_%d"
+#define MODULE_RXLOS_FORMAT             "/sys/bus/i2c/devices/%d-00%d/module_rx_los_%d"
+#define MODULE_TXFAULT_FORMAT           "/sys/bus/i2c/devices/%d-00%d/module_tx_fault_%d"
+#define MODULE_TXDISABLE_FORMAT         "/sys/bus/i2c/devices/%d-00%d/module_tx_disable_%d"
+#define MODULE_RESET_FORMAT             "/sys/bus/i2c/devices/%d-00%d/module_reset_%d"
+#define MODULE_LPMODE_FORMAT            "/sys/bus/i2c/devices/%d-00%d/module_lpmode_%d"
+#define MODULE_PRESENT_ALL_FORMAT       "/sys/bus/i2c/devices/%d-00%d/module_present_all"
+#define MODULE_RXLOS_ALL_FORMAT         "/sys/bus/i2c/devices/%d-00%d/module_rx_los_all"
 
 /*QSFP tx_disable*/
 #define PORT_EEPROM_DEVADDR             0x50
@@ -233,8 +260,13 @@ onlp_sfpi_is_present(int port)
      */
     int present;
     int addr = (port < 24) ? 61 : 62;
-    
-	if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, addr, front_port_to_driver_port(port)) < 0) {
+    int bus = cpld_bus();
+
+    if (bus < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, bus, addr, front_port_to_driver_port(port)) < 0) {
         AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n", port);
         return ONLP_STATUS_E_INTERNAL;
     }
@@ -247,9 +279,17 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 {
     uint32_t bytes[7];
     FILE* fp;
+    char path[64];
+    int bus = cpld_bus();
+
+    if (bus < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
 
     /* Read present status of port 0~23 */
-    fp = fopen(MODULE_PRESENT_ALL_ATTR_CPLD2, "r");
+    snprintf(path, sizeof(path), MODULE_PRESENT_ALL_FORMAT, bus, 61);
+    fp = fopen(path, "r");
     if(fp == NULL) {
         AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD2.");
         return ONLP_STATUS_E_INTERNAL;
@@ -264,7 +304,8 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
     }
 
     /* Read present status of port 24~53 */
-    fp = fopen(MODULE_PRESENT_ALL_ATTR_CPLD3, "r");
+    snprintf(path, sizeof(path), MODULE_PRESENT_ALL_FORMAT, bus, 62);
+    fp = fopen(path, "r");
     if(fp == NULL) {
         AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD3.");
         return ONLP_STATUS_E_INTERNAL;
@@ -306,17 +347,20 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
     uint32_t bytes[6];
     uint32_t *ptr = bytes;
     FILE* fp;
+    char path[64];
+    int bus = cpld_bus();
 
     /* Read present status of port 0~23 */
     int addr, i = 0;
 
+    if (bus < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
     for (addr = 61; addr <= 62; addr++) {
-        if (addr == 61) {
-            fp = fopen(MODULE_RXLOS_ALL_ATTR_CPLD2, "r");
-        }
-        else {
-            fp = fopen(MODULE_RXLOS_ALL_ATTR_CPLD3, "r");
-        }
+        snprintf(path, sizeof(path), MODULE_RXLOS_ALL_FORMAT, bus, addr);
+        fp = fopen(path, "r");
 
         if(fp == NULL) {
             AIM_LOG_ERROR("Unable to open the module_rx_los_all device file of CPLD(0x%d)", addr);
@@ -444,6 +488,12 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
     VALIDATE_PORT(port);
 
     int addr = (port < 24) ? 61 : 62;
+    int bus = cpld_bus();
+
+    if (bus < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
 
     switch(control)
         {
@@ -454,7 +504,7 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
                 if(present == 1)
                 {
                     if (port >= SFP_PORT_MIN && port <= SFP_PORT_MAX) { //SFP
-                        if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT, addr, (port+1)) < 0) {
+                        if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
                             AIM_LOG_ERROR("Unable to write tx_disable status to port(%d)\r\n", port);
                             rv = ONLP_STATUS_E_INTERNAL;
                         }
@@ -484,7 +534,7 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
         case ONLP_SFP_CONTROL_RESET:
             {
                 VALIDATE_QSFP(port);
-                if (onlp_file_write_int(value, MODULE_RESET_FORMAT, addr, (port+1)) < 0) {
+                if (onlp_file_write_int(value, MODULE_RESET_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to write reset status to port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }
@@ -497,7 +547,7 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
         case ONLP_SFP_CONTROL_LP_MODE:
             {
                 VALIDATE_QSFP(port);
-                if (onlp_file_write_int(value, MODULE_LPMODE_FORMAT, addr, (port+1)) < 0) {
+                if (onlp_file_write_int(value, MODULE_LPMODE_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to write LP mode status to port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }
@@ -525,13 +575,19 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
     VALIDATE_PORT(port);
 
     int addr = (port < 24) ? 61 : 62;
+    int bus = cpld_bus();
+
+    if (bus < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
 
     switch(control)
         {
         case ONLP_SFP_CONTROL_RX_LOS:
             {
                 VALIDATE_SFP(port);
-            	if (onlp_file_read_int(value, MODULE_RXLOS_FORMAT, addr, (port+1)) < 0) {
+            	if (onlp_file_read_int(value, MODULE_RXLOS_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to read rx_loss status from port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }
@@ -544,7 +600,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
         case ONLP_SFP_CONTROL_TX_FAULT:
             {
                 VALIDATE_SFP(port);
-            	if (onlp_file_read_int(value, MODULE_TXFAULT_FORMAT, addr, (port+1)) < 0) {
+            	if (onlp_file_read_int(value, MODULE_TXFAULT_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to read tx_fault status from port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }
@@ -560,7 +616,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
                 present = onlp_sfpi_is_present(port);
                 if(present == 1){
                     if (port >= SFP_PORT_MIN && port <= SFP_PORT_MAX) { //SFP
-                        if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT, addr, (port+1)) < 0) {
+                        if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
                             AIM_LOG_ERROR("Unable to read tx_disabled status from port(%d)\r\n", port);
                             rv = ONLP_STATUS_E_INTERNAL;
                         }
@@ -591,7 +647,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
         case ONLP_SFP_CONTROL_RESET: 
             {
                 VALIDATE_QSFP(port);
-                if (onlp_file_read_int(value, MODULE_RESET_FORMAT, addr, (port+1)) < 0) {
+                if (onlp_file_read_int(value, MODULE_RESET_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to read reset status from port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }
@@ -604,7 +660,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
         case ONLP_SFP_CONTROL_LP_MODE: 
             {
                 VALIDATE_QSFP(port);
-                if (onlp_file_read_int(value, MODULE_LPMODE_FORMAT, addr, (port+1)) < 0) {
+                if (onlp_file_read_int(value, MODULE_LPMODE_FORMAT, bus, addr, (port+1)) < 0) {
                     AIM_LOG_ERROR("Unable to read LP mode status from port(%d)\r\n", port);
                     rv = ONLP_STATUS_E_INTERNAL;
                 }

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
@@ -91,7 +91,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int   i, siz=NUM_OF_CPLD, v[NUM_OF_CPLD]={0};
     int   fd, len, nbytes = 10;
-    onlp_onie_info_t onie;
+    onlp_onie_info_t onie = {0};
     char  r_data[10]   = {0};
     char  fullpath[65] = {0};
     char *bios_ver = NULL;

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
@@ -57,12 +57,36 @@
 
 #define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 
-static char arr_cplddev_name[NUM_OF_CPLD][10] =
+/*
+ * CPLDs live on the i801 SMBus, but its i2c bus number varies by kernel
+ * (4.14 enumerated i801 as i2c-0, 6.12 lands iSMT first and pushes i801
+ * to i2c-1). Resolve the bus by scanning for the first one that exposes
+ * a 0x60 CPLD device, and cache the resulting "N-006X" strings.
+ */
+#define CPLD_BUS_SCAN_MAX 16
+static char arr_cplddev_name[NUM_OF_CPLD][10];
+
+static int resolve_cpld_bus(void)
 {
- "0-0060",
- "0-0061",
- "0-0062"
-};
+    static int resolved_bus = -1;
+    char probe[64];
+    int b;
+
+    if (resolved_bus >= 0) return resolved_bus;
+
+    for (b = 0; b < CPLD_BUS_SCAN_MAX; b++) {
+        snprintf(probe, sizeof(probe),
+                 "%s%d-0060/version", PREFIX_PATH_ON_CPLD_DEV, b);
+        if (access(probe, R_OK) == 0) {
+            resolved_bus = b;
+            snprintf(arr_cplddev_name[0], sizeof(arr_cplddev_name[0]), "%d-0060", b);
+            snprintf(arr_cplddev_name[1], sizeof(arr_cplddev_name[1]), "%d-0061", b);
+            snprintf(arr_cplddev_name[2], sizeof(arr_cplddev_name[2]), "%d-0062", b);
+            return b;
+        }
+    }
+    return -1;
+}
 
 const char*
 onlp_sysi_platform_get(void)
@@ -74,7 +98,12 @@ int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
     uint8_t* rdata = aim_zmalloc(256);
-    if(onlp_file_read(rdata, 256, size, IDPROM_PATH) == ONLP_STATUS_OK) {
+    if(onlp_file_read(rdata, 256, size, IDPROM_PATH_1) == ONLP_STATUS_OK) {
+        if(*size == 256) {
+            *data = rdata;
+            return ONLP_STATUS_OK;
+        }
+    } else if(onlp_file_read(rdata, 256, size, IDPROM_PATH_2) == ONLP_STATUS_OK) {
         if(*size == 256) {
             *data = rdata;
             return ONLP_STATUS_OK;
@@ -96,6 +125,11 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     char  fullpath[65] = {0};
     char *bios_ver = NULL;
 
+    if (resolve_cpld_bus() < 0) {
+        AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
     for (i=0; i<siz; i++)
     {
         sprintf(fullpath, "%s%s/version", PREFIX_PATH_ON_CPLD_DEV, arr_cplddev_name[i]);
@@ -105,7 +139,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     }
 
     onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
-    onlp_onie_decode_file(&onie, IDPROM_PATH);
+    if (onlp_onie_decode_file(&onie, IDPROM_PATH_1) != ONLP_STATUS_OK) {
+        onlp_onie_decode_file(&onie, IDPROM_PATH_2);
+    }
 
     if(3==NUM_OF_CPLD)
         pi->cpld_versions = aim_fstrdup(

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/sysi.c
@@ -57,37 +57,6 @@
 
 #define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
 
-/*
- * CPLDs live on the i801 SMBus, but its i2c bus number varies by kernel
- * (4.14 enumerated i801 as i2c-0, 6.12 lands iSMT first and pushes i801
- * to i2c-1). Resolve the bus by scanning for the first one that exposes
- * a 0x60 CPLD device, and cache the resulting "N-006X" strings.
- */
-#define CPLD_BUS_SCAN_MAX 16
-static char arr_cplddev_name[NUM_OF_CPLD][10];
-
-static int resolve_cpld_bus(void)
-{
-    static int resolved_bus = -1;
-    char probe[64];
-    int b;
-
-    if (resolved_bus >= 0) return resolved_bus;
-
-    for (b = 0; b < CPLD_BUS_SCAN_MAX; b++) {
-        snprintf(probe, sizeof(probe),
-                 "%s%d-0060/version", PREFIX_PATH_ON_CPLD_DEV, b);
-        if (access(probe, R_OK) == 0) {
-            resolved_bus = b;
-            snprintf(arr_cplddev_name[0], sizeof(arr_cplddev_name[0]), "%d-0060", b);
-            snprintf(arr_cplddev_name[1], sizeof(arr_cplddev_name[1]), "%d-0061", b);
-            snprintf(arr_cplddev_name[2], sizeof(arr_cplddev_name[2]), "%d-0062", b);
-            return b;
-        }
-    }
-    return -1;
-}
-
 const char*
 onlp_sysi_platform_get(void)
 {
@@ -120,19 +89,22 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int   i, siz=NUM_OF_CPLD, v[NUM_OF_CPLD]={0};
     int   fd, len, nbytes = 10;
+    int   bus;
     onlp_onie_info_t onie = {0};
     char  r_data[10]   = {0};
     char  fullpath[65] = {0};
     char *bios_ver = NULL;
 
-    if (resolve_cpld_bus() < 0) {
+    bus = as5812_54x_cpld_bus();
+    if (bus < 0) {
         AIM_LOG_ERROR("Unable to locate CPLD i2c bus");
         return ONLP_STATUS_E_INTERNAL;
     }
 
     for (i=0; i<siz; i++)
     {
-        sprintf(fullpath, "%s%s/version", PREFIX_PATH_ON_CPLD_DEV, arr_cplddev_name[i]);
+        snprintf(fullpath, sizeof(fullpath),
+                 "%s%d-006%d/version", PREFIX_PATH_ON_CPLD_DEV, bus, i);
         OPEN_READ_FILE(fd,fullpath,r_data,nbytes,len);
         v[i]=atoi(r_data);
         memset(r_data, 0, len);
@@ -152,8 +124,12 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     else
         printf("This CPLD numbers are wrong !! \n");
 
+    /* If onie decode failed on both paths, onie.onie_version stays NULL;
+     * passing NULL to %s is UB. Use a placeholder. Same for bios_ver if
+     * the DMI sysfs read failed. */
     pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s",
-                                    bios_ver, onie.onie_version);
+                                    bios_ver ? bios_ver : "(unknown)",
+                                    onie.onie_version ? onie.onie_version : "(unknown)");
 
     AIM_FREE_IF_PTR(bios_ver);
 

--- a/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as5812-54x/onlp/builds/x86_64_accton_as5812_54x/module/src/thermali.c
@@ -123,6 +123,7 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int local_id;
     int psu_id;
+    int power_good = 0;
     psu_type_t psu_type;
 
     VALIDATE(id);
@@ -137,7 +138,22 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
         return rv;
     }
 
+    /* Chassis sensors: nothing more to do, just read the value. */
+    if (local_id != THERMAL_1_ON_PSU1 && local_id != THERMAL_1_ON_PSU2) {
+        return onlp_file_read_int(&info->mcelsius, devfiles[local_id]);
+    }
+
+    /* PSU-attached thermal: if the PSU has no power, the cpr_4011 / ym2401
+     * PMBus sensor won't respond. Mark FAILED so a 0 mcelsius reading
+     * isn't mistaken for an actual temperature.
+     */
     psu_id   = local_id - THERMAL_1_ON_PSU1 + 1;
+    if (psu_status_info_get(psu_id, 1, "psu_power_good", &power_good) == 0 &&
+        power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_THERMAL_STATUS_FAILED;
+        return ONLP_STATUS_OK;
+    }
+
     psu_type = get_psu_type(psu_id, NULL, 0);
 
     if (psu_type == PSU_TYPE_AC_3YPOWER_F2B || psu_type == PSU_TYPE_AC_3YPOWER_B2F  ) {

--- a/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/lib/x86-64-accton-as5812-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/lib/x86-64-accton-as5812-54x-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as5812-54x-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-4-14
+      <<: *kernel-6-12
 
     args: >-
       nopat

--- a/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/python/x86_64_accton_as5812_54x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/python/x86_64_accton_as5812_54x_r0/__init__.py
@@ -1,6 +1,12 @@
 from onl.platform.base import *
 from onl.platform.accton import *
 
+def get_i2c_bus_num_offset():
+    cmd = 'cat /sys/bus/i2c/devices/i2c-0/name'
+    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    return -1 if b'iSMT' in stdout else 0 # the iSMT adapter may get i2c bus 0, hence the offset -1
+
 class OnlPlatform_x86_64_accton_as5812_54x_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x10_6x40):
 
@@ -15,16 +21,24 @@ class OnlPlatform_x86_64_accton_as5812_54x_r0(OnlPlatformAccton,
         for m in [ 'cpld', 'fan', 'psu', 'leds' ]:
             self.insmod("x86-64-accton-as5812-54x-%s.ko" % m)
 
+        # 4.14 enumerates i801 as i2c-0 (CPLDs live there); 6.12 enumerates
+        # iSMT as i2c-0 first, pushing i801 to i2c-1. CPLDs are wired to the
+        # i801 controller, so re-anchor them to whichever bus i801 ended up
+        # on. `bus_offset` is 0 on 4.14 and -1 on 6.12.
+        bus_offset = get_i2c_bus_num_offset()
+        i801_bus = 0 - bus_offset
+
         ########### initialize I2C bus 0 ###########
 
-        # initialize CPLDs
+        # initialize CPLDs (on i801)
         self.new_i2c_devices(
             [
-                ('as5812_54x_cpld1', 0x60, 0),
-                ('as5812_54x_cpld2', 0x61, 0),
-                ('as5812_54x_cpld3', 0x62, 0),
+                ('as5812_54x_cpld1', 0x60, i801_bus),
+                ('as5812_54x_cpld2', 0x61, i801_bus),
+                ('as5812_54x_cpld3', 0x62, i801_bus),
                 ]
             )
+
         # initialize SFP devices
         for port in range(1, 49):
             self.new_i2c_device('optoe2', 0x50, port+1)
@@ -40,11 +54,15 @@ class OnlPlatform_x86_64_accton_as5812_54x_r0(OnlPlatformAccton,
         subprocess.call('echo port51 > /sys/bus/i2c/devices/54-0050/port_name', shell=True)
         subprocess.call('echo port54 > /sys/bus/i2c/devices/55-0050/port_name', shell=True)
 
-        ########### initialize I2C bus 1 ###########
+        ########### initialize I2C bus 1 (iSMT) ###########
+        # The iSMT adapter probe order varies between kernels: 4.14 had iSMT
+        # as i2c-1, 6.12 enumerates iSMT first as i2c-0. Without `bus_offset`
+        # the multiplexer and IDPROM get instantiated on the i801 SMBus
+        # where they NACK (pca954x probe failed, no eeprom sysfs node).
         self.new_i2c_devices(
             [
                 # initiate multiplexer (PCA9548)
-                ('pca9548', 0x70, 1),
+                ('pca9548', 0x70, 1 + bus_offset),
 
                 # initiate PSU-1 AC Power
                 ('as5812_54x_psu1', 0x38, 57),
@@ -64,7 +82,7 @@ class OnlPlatform_x86_64_accton_as5812_54x_r0(OnlPlatformAccton,
                 ('lm75', 0x4a, 63),
 
                 # System EEPROM
-                ('24c02', 0x57, 1),
+                ('24c02', 0x57, 1 + bus_offset),
                 ]
             )
         return True

--- a/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/python/x86_64_accton_as5812_54x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/python/x86_64_accton_as5812_54x_r0/__init__.py
@@ -85,4 +85,12 @@ class OnlPlatform_x86_64_accton_as5812_54x_r0(OnlPlatformAccton,
                 ('24c02', 0x57, 1 + bus_offset),
                 ]
             )
+
+        # Leave the pca9548 selected on the last-used channel rather than
+        # deselecting it after every i2c transaction. Without this, every
+        # downstream xfer on bus 57/58/61/62/63 toggles the mux on iSMT,
+        # which on 6.12 stresses the iSMT timing enough to occasionally
+        # drop transactions. Matches the AS5835 / SONiC convention.
+        subprocess.call('echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state > /dev/null', shell=True)
+
         return True


### PR DESCRIPTION
## Summary

Upgrades AS5812-54X from kernel 4.14 to 6.12 LTS.

### Config
- `modules/PKG.yml`, `modules/builds/Makefile`: `KERNELS` switched to `onl-kernel-6.12-lts-x86-64-all`
- `platform-config/r0/.../x86-64-accton-as5812-54x-r0.yml`: kernel anchor `*kernel-4-14` → `*kernel-6-12`

### Build layout
- Moved `cpld/fan/leds/psu.c` from `modules/builds/` into `modules/builds/src/` with an explicit Kbuild (`obj-m += ...`). Newer kbuild builds each top-level `.c` as its own standalone module, so leds.c's references to `as5812_54x_cpld_read/write` failed `modpost` even though cpld.c exports them. The src/ subdir mirrors the convention already used by as5835-54x and other 6.12-ready platforms.

### Driver API (4.14 → 6.12)
- `cpld.c`:
  - `i2c_driver.probe()` single-arg signature; restore device id via `i2c_client_get_device_id()`
  - `i2c_mux_add_adapter()` drops the removed `class` argument (and the local `class` variable)
  - `i2c_driver.remove()` returns `void`
- `psu.c`:
  - `i2c_driver.probe()` single-arg signature + `i2c_client_get_device_id()` (body still consumes `dev_id->driver_data`)
  - `i2c_driver.remove()` returns `void`
- `fan.c`, `leds.c`: `platform_driver.remove()` returns `void` per 6.11+ API

### ONLP
- `platform_lib.h`: `IDPROM_PATH` switched from the pci-bus path (`/sys/devices/pci0000:00/.../1-0057/eeprom`) to `/sys/bus/i2c/devices/1-0057/eeprom`; the old path no longer enumerates on 6.12
- `sysi.c`: zero-init `onlp_onie_info_t onie` to avoid the double-free path that has bitten other platforms on this branch
