### PR TITLE
[AS7816-64X] Upgrade kernel from 4.14 to 6.12

### DIFF
--- a/packages/platforms/accton/x86-64/as7816-64x/modules/PKG.yml
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7816-64x ARCH=amd64 KERNELS="onl-kernel-4.14-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=accton BASENAME=x86-64-accton-as7816-64x ARCH=amd64 KERNELS="onl-kernel-6.12-lts-x86-64-all:amd64"

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/Makefile
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/Makefile
@@ -1,5 +1,5 @@
-KERNELS := onl-kernel-4.14-lts-x86-64-all:amd64
-KMODULES := $(wildcard *.c)
+KERNELS := onl-kernel-6.12-lts-x86-64-all:amd64
+KMODULES := src
 VENDOR := accton
 BASENAME := x86-64-accton-as7816-64x
 ARCH := x86_64

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/Makefile
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/Makefile
@@ -1,0 +1,4 @@
+obj-m += accton_i2c_cpld.o
+obj-m += x86-64-accton-as7816-64x-cpld1.o
+obj-m += x86-64-accton-as7816-64x-fan.o
+obj-m += x86-64-accton-as7816-64x-leds.o

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/accton_i2c_cpld.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/accton_i2c_cpld.c
@@ -1,0 +1,327 @@
+/*
+ * A hwmon driver for the accton_i2c_cpld
+ *
+ * Copyright (C) 2013 Accton Technology Corporation.
+ * Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on ad7414.c
+ * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/i2c.h>
+#include <linux/slab.h>
+#include <linux/list.h>
+#include <linux/dmi.h>
+
+static LIST_HEAD(cpld_client_list);
+static struct mutex	 list_lock;
+
+struct cpld_client_node {
+	struct i2c_client *client;
+	struct list_head   list;
+};
+
+/* Addresses scanned for accton_i2c_cpld
+ */
+static const unsigned short normal_i2c[] = { 0x31, 0x35, 0x60, 0x61, 0x62, 0x64, I2C_CLIENT_END };
+
+static ssize_t show_cpld_version(struct device *dev, struct device_attribute *attr, char *buf)
+{
+    int val = 0;
+    struct i2c_client *client = to_i2c_client(dev);
+	
+	val = i2c_smbus_read_byte_data(client, 0x1);
+
+    if (val < 0) {
+        dev_dbg(&client->dev, "cpld(0x%x) reg(0x1) err %d\n", client->addr, val);
+    }
+	
+    return sprintf(buf, "%d", val);
+}	
+
+static struct device_attribute ver = __ATTR(version, 0600, show_cpld_version, NULL);
+
+static void accton_i2c_cpld_add_client(struct i2c_client *client)
+{
+	struct cpld_client_node *node = kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
+	
+	if (!node) {
+		dev_dbg(&client->dev, "Can't allocate cpld_client_node (0x%x)\n", client->addr);
+		return;
+	}
+	
+	node->client = client;
+	
+	mutex_lock(&list_lock);
+	list_add(&node->list, &cpld_client_list);
+	mutex_unlock(&list_lock);
+}
+
+static void accton_i2c_cpld_remove_client(struct i2c_client *client)
+{
+	struct list_head		*list_node = NULL;
+	struct cpld_client_node *cpld_node = NULL;
+	int found = 0;
+	
+	mutex_lock(&list_lock);
+
+	list_for_each(list_node, &cpld_client_list)
+	{
+		cpld_node = list_entry(list_node, struct cpld_client_node, list);
+		
+		if (cpld_node->client == client) {
+			found = 1;
+			break;
+		}
+	}
+	
+	if (found) {
+		list_del(list_node);
+		kfree(cpld_node);
+	}
+	
+	mutex_unlock(&list_lock);
+}
+
+static int accton_i2c_cpld_probe(struct i2c_client *client)
+{
+	int status;
+
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+		dev_dbg(&client->dev, "i2c_check_functionality failed (0x%x)\n", client->addr);
+		status = -EIO;
+		goto exit;
+	}
+
+	status = sysfs_create_file(&client->dev.kobj, &ver.attr);
+	if (status) {
+		goto exit;
+	}
+
+	dev_info(&client->dev, "chip found\n");
+	accton_i2c_cpld_add_client(client);
+	
+	return 0;
+
+exit:
+	return status;
+}
+
+static void accton_i2c_cpld_remove(struct i2c_client *client)
+{
+	sysfs_remove_file(&client->dev.kobj, &ver.attr);
+	accton_i2c_cpld_remove_client(client);
+}
+
+static const struct i2c_device_id accton_i2c_cpld_id[] = {
+	{ "accton_i2c_cpld", 0 },
+	{}
+};
+MODULE_DEVICE_TABLE(i2c, accton_i2c_cpld_id);
+
+static struct i2c_driver accton_i2c_cpld_driver = {
+	.class		= I2C_CLASS_HWMON,
+	.driver = {
+		.name = "accton_i2c_cpld",
+	},
+	.probe		= accton_i2c_cpld_probe,
+	.remove	   	= accton_i2c_cpld_remove,
+	.id_table	= accton_i2c_cpld_id,
+	.address_list = normal_i2c,
+};
+
+int accton_i2c_cpld_read(unsigned short cpld_addr, u8 reg)
+{
+	struct list_head   *list_node = NULL;
+	struct cpld_client_node *cpld_node = NULL;
+	int ret = -EPERM;
+	
+	mutex_lock(&list_lock);
+
+	list_for_each(list_node, &cpld_client_list)
+	{
+		cpld_node = list_entry(list_node, struct cpld_client_node, list);
+		
+		if (cpld_node->client->addr == cpld_addr) {
+			ret = i2c_smbus_read_byte_data(cpld_node->client, reg);
+			break;
+		}
+	}
+	
+	mutex_unlock(&list_lock);
+
+	return ret;
+}
+EXPORT_SYMBOL(accton_i2c_cpld_read);
+
+int accton_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
+{
+	struct list_head   *list_node = NULL;
+	struct cpld_client_node *cpld_node = NULL;
+	int ret = -EIO;
+	
+	mutex_lock(&list_lock);
+
+	list_for_each(list_node, &cpld_client_list)
+	{
+		cpld_node = list_entry(list_node, struct cpld_client_node, list);
+		
+		if (cpld_node->client->addr == cpld_addr) {
+			ret = i2c_smbus_write_byte_data(cpld_node->client, reg, value);
+			break;
+		}
+	}
+	
+	mutex_unlock(&list_lock);
+
+	return ret;
+}
+EXPORT_SYMBOL(accton_i2c_cpld_write);
+
+static int __init accton_i2c_cpld_init(void)
+{
+	mutex_init(&list_lock);
+	return i2c_add_driver(&accton_i2c_cpld_driver);
+}
+
+static void __exit accton_i2c_cpld_exit(void)
+{
+	i2c_del_driver(&accton_i2c_cpld_driver);
+}
+	
+static struct dmi_system_id as7512_dmi_table[] = {
+	{
+		.ident = "Accton AS7512",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS7512"),
+		},
+	},
+	{
+		.ident = "Accton AS7512",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS7512"),
+		},
+	},
+};
+
+int platform_accton_as7512_32x(void)
+{
+	return dmi_check_system(as7512_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as7512_32x);
+
+static struct dmi_system_id as7712_dmi_table[] = {
+	{
+		.ident = "Accton AS7712",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS7712"),
+		},
+	},
+	{
+		.ident = "Accton AS7712",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS7712"),
+		},
+	},
+};
+
+int platform_accton_as7712_32x(void)
+{
+	return dmi_check_system(as7712_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as7712_32x);
+
+static struct dmi_system_id as5812_54t_dmi_table[] = {
+	{
+		.ident = "Accton AS5812 54t",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS5812-54T"),
+		},
+	},
+	{
+		.ident = "Accton AS5812 54t",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS5812-54T"),
+		},
+	},
+};
+
+int platform_accton_as5812_54t(void)
+{
+	return dmi_check_system(as5812_54t_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as5812_54t);
+
+static struct dmi_system_id as5512_54x_dmi_table[] = {
+	{
+		.ident = "Accton AS5512",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS5512"),
+		},
+	},
+	{
+		.ident = "Accton AS5512",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS5512"),
+		},
+	},
+};
+
+int platform_accton_as5512_54x(void)
+{
+	return dmi_check_system(as5512_54x_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as5512_54x);
+
+static struct dmi_system_id as7716_dmi_table[] = {
+        {
+                .ident = "Accton AS7716",
+                .matches = {
+                        DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+                        DMI_MATCH(DMI_PRODUCT_NAME, "AS7716"),
+                },
+        },
+        {
+                .ident = "Accton AS7716",
+                .matches = {
+                        DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+                        DMI_MATCH(DMI_PRODUCT_NAME, "AS7716"),
+                },
+        },
+};
+
+int platform_accton_as7716_32x(void)
+{
+        return dmi_check_system(as7716_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as7716_32x);
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("accton_i2c_cpld driver");
+MODULE_LICENSE("GPL");
+
+module_init(accton_i2c_cpld_init);
+module_exit(accton_i2c_cpld_exit);

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/accton_i2c_cpld.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/accton_i2c_cpld.c
@@ -1,5 +1,5 @@
 /*
- * A hwmon driver for the accton_i2c_cpld
+ * A driver for the accton_i2c_cpld
  *
  * Copyright (C) 2013 Accton Technology Corporation.
  * Brandon Chuang <brandon_chuang@accton.com.tw>
@@ -20,83 +20,34 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * Local (per-platform) copy for AS7816-64X. The shared driver under
+ * packages/platforms/accton/x86-64/modules/ is still pinned to 4.14.
+ * Only the bits 7816 actually exercises (binding + sysfs version
+ * attribute) are kept here; the cross-module read/write helpers and
+ * other-platform DMI tables in the shared driver are not needed.
  */
 
 #include <linux/module.h>
 #include <linux/i2c.h>
-#include <linux/slab.h>
-#include <linux/list.h>
-#include <linux/dmi.h>
 
-static LIST_HEAD(cpld_client_list);
-static struct mutex	 list_lock;
-
-struct cpld_client_node {
-	struct i2c_client *client;
-	struct list_head   list;
-};
-
-/* Addresses scanned for accton_i2c_cpld
- */
-static const unsigned short normal_i2c[] = { 0x31, 0x35, 0x60, 0x61, 0x62, 0x64, I2C_CLIENT_END };
+static const unsigned short normal_i2c[] = { 0x62, 0x64, 0x66, I2C_CLIENT_END };
 
 static ssize_t show_cpld_version(struct device *dev, struct device_attribute *attr, char *buf)
 {
-    int val = 0;
-    struct i2c_client *client = to_i2c_client(dev);
-	
+	int val = 0;
+	struct i2c_client *client = to_i2c_client(dev);
+
 	val = i2c_smbus_read_byte_data(client, 0x1);
 
-    if (val < 0) {
-        dev_dbg(&client->dev, "cpld(0x%x) reg(0x1) err %d\n", client->addr, val);
-    }
-	
-    return sprintf(buf, "%d", val);
-}	
+	if (val < 0) {
+		dev_dbg(&client->dev, "cpld(0x%x) reg(0x1) err %d\n", client->addr, val);
+	}
+
+	return sprintf(buf, "%d", val);
+}
 
 static struct device_attribute ver = __ATTR(version, 0600, show_cpld_version, NULL);
-
-static void accton_i2c_cpld_add_client(struct i2c_client *client)
-{
-	struct cpld_client_node *node = kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
-	
-	if (!node) {
-		dev_dbg(&client->dev, "Can't allocate cpld_client_node (0x%x)\n", client->addr);
-		return;
-	}
-	
-	node->client = client;
-	
-	mutex_lock(&list_lock);
-	list_add(&node->list, &cpld_client_list);
-	mutex_unlock(&list_lock);
-}
-
-static void accton_i2c_cpld_remove_client(struct i2c_client *client)
-{
-	struct list_head		*list_node = NULL;
-	struct cpld_client_node *cpld_node = NULL;
-	int found = 0;
-	
-	mutex_lock(&list_lock);
-
-	list_for_each(list_node, &cpld_client_list)
-	{
-		cpld_node = list_entry(list_node, struct cpld_client_node, list);
-		
-		if (cpld_node->client == client) {
-			found = 1;
-			break;
-		}
-	}
-	
-	if (found) {
-		list_del(list_node);
-		kfree(cpld_node);
-	}
-	
-	mutex_unlock(&list_lock);
-}
 
 static int accton_i2c_cpld_probe(struct i2c_client *client)
 {
@@ -104,28 +55,20 @@ static int accton_i2c_cpld_probe(struct i2c_client *client)
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
 		dev_dbg(&client->dev, "i2c_check_functionality failed (0x%x)\n", client->addr);
-		status = -EIO;
-		goto exit;
+		return -EIO;
 	}
 
 	status = sysfs_create_file(&client->dev.kobj, &ver.attr);
-	if (status) {
-		goto exit;
-	}
+	if (status)
+		return status;
 
 	dev_info(&client->dev, "chip found\n");
-	accton_i2c_cpld_add_client(client);
-	
 	return 0;
-
-exit:
-	return status;
 }
 
 static void accton_i2c_cpld_remove(struct i2c_client *client)
 {
 	sysfs_remove_file(&client->dev.kobj, &ver.attr);
-	accton_i2c_cpld_remove_client(client);
 }
 
 static const struct i2c_device_id accton_i2c_cpld_id[] = {
@@ -135,193 +78,17 @@ static const struct i2c_device_id accton_i2c_cpld_id[] = {
 MODULE_DEVICE_TABLE(i2c, accton_i2c_cpld_id);
 
 static struct i2c_driver accton_i2c_cpld_driver = {
-	.class		= I2C_CLASS_HWMON,
 	.driver = {
 		.name = "accton_i2c_cpld",
 	},
 	.probe		= accton_i2c_cpld_probe,
-	.remove	   	= accton_i2c_cpld_remove,
+	.remove		= accton_i2c_cpld_remove,
 	.id_table	= accton_i2c_cpld_id,
 	.address_list = normal_i2c,
 };
-
-int accton_i2c_cpld_read(unsigned short cpld_addr, u8 reg)
-{
-	struct list_head   *list_node = NULL;
-	struct cpld_client_node *cpld_node = NULL;
-	int ret = -EPERM;
-	
-	mutex_lock(&list_lock);
-
-	list_for_each(list_node, &cpld_client_list)
-	{
-		cpld_node = list_entry(list_node, struct cpld_client_node, list);
-		
-		if (cpld_node->client->addr == cpld_addr) {
-			ret = i2c_smbus_read_byte_data(cpld_node->client, reg);
-			break;
-		}
-	}
-	
-	mutex_unlock(&list_lock);
-
-	return ret;
-}
-EXPORT_SYMBOL(accton_i2c_cpld_read);
-
-int accton_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
-{
-	struct list_head   *list_node = NULL;
-	struct cpld_client_node *cpld_node = NULL;
-	int ret = -EIO;
-	
-	mutex_lock(&list_lock);
-
-	list_for_each(list_node, &cpld_client_list)
-	{
-		cpld_node = list_entry(list_node, struct cpld_client_node, list);
-		
-		if (cpld_node->client->addr == cpld_addr) {
-			ret = i2c_smbus_write_byte_data(cpld_node->client, reg, value);
-			break;
-		}
-	}
-	
-	mutex_unlock(&list_lock);
-
-	return ret;
-}
-EXPORT_SYMBOL(accton_i2c_cpld_write);
-
-static int __init accton_i2c_cpld_init(void)
-{
-	mutex_init(&list_lock);
-	return i2c_add_driver(&accton_i2c_cpld_driver);
-}
-
-static void __exit accton_i2c_cpld_exit(void)
-{
-	i2c_del_driver(&accton_i2c_cpld_driver);
-}
-	
-static struct dmi_system_id as7512_dmi_table[] = {
-	{
-		.ident = "Accton AS7512",
-		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS7512"),
-		},
-	},
-	{
-		.ident = "Accton AS7512",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS7512"),
-		},
-	},
-};
-
-int platform_accton_as7512_32x(void)
-{
-	return dmi_check_system(as7512_dmi_table);
-}
-EXPORT_SYMBOL(platform_accton_as7512_32x);
-
-static struct dmi_system_id as7712_dmi_table[] = {
-	{
-		.ident = "Accton AS7712",
-		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS7712"),
-		},
-	},
-	{
-		.ident = "Accton AS7712",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS7712"),
-		},
-	},
-};
-
-int platform_accton_as7712_32x(void)
-{
-	return dmi_check_system(as7712_dmi_table);
-}
-EXPORT_SYMBOL(platform_accton_as7712_32x);
-
-static struct dmi_system_id as5812_54t_dmi_table[] = {
-	{
-		.ident = "Accton AS5812 54t",
-		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS5812-54T"),
-		},
-	},
-	{
-		.ident = "Accton AS5812 54t",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS5812-54T"),
-		},
-	},
-};
-
-int platform_accton_as5812_54t(void)
-{
-	return dmi_check_system(as5812_54t_dmi_table);
-}
-EXPORT_SYMBOL(platform_accton_as5812_54t);
-
-static struct dmi_system_id as5512_54x_dmi_table[] = {
-	{
-		.ident = "Accton AS5512",
-		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS5512"),
-		},
-	},
-	{
-		.ident = "Accton AS5512",
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "AS5512"),
-		},
-	},
-};
-
-int platform_accton_as5512_54x(void)
-{
-	return dmi_check_system(as5512_54x_dmi_table);
-}
-EXPORT_SYMBOL(platform_accton_as5512_54x);
-
-static struct dmi_system_id as7716_dmi_table[] = {
-        {
-                .ident = "Accton AS7716",
-                .matches = {
-                        DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
-                        DMI_MATCH(DMI_PRODUCT_NAME, "AS7716"),
-                },
-        },
-        {
-                .ident = "Accton AS7716",
-                .matches = {
-                        DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
-                        DMI_MATCH(DMI_PRODUCT_NAME, "AS7716"),
-                },
-        },
-};
-
-int platform_accton_as7716_32x(void)
-{
-        return dmi_check_system(as7716_dmi_table);
-}
-EXPORT_SYMBOL(platform_accton_as7716_32x);
 
 MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
 MODULE_DESCRIPTION("accton_i2c_cpld driver");
 MODULE_LICENSE("GPL");
 
-module_init(accton_i2c_cpld_init);
-module_exit(accton_i2c_cpld_exit);
+module_i2c_driver(accton_i2c_cpld_driver);

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-cpld1.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-cpld1.c
@@ -956,8 +956,28 @@ static void as7816_64x_cpld_remove_client(struct i2c_client *client)
 	mutex_unlock(&list_lock);
 }
 
-static int as7816_64x_cpld_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static umode_t as7816_64x_cpld_is_visible(const void *drvdata,
+                  enum hwmon_sensor_types type,
+                  u32 attr, int channel)
+{
+    return 0;
+}
+
+static const struct hwmon_channel_info *as7816_64x_cpld_info[] = {
+    HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ),
+    NULL,
+};
+
+static const struct hwmon_ops as7816_64x_cpld_hwmon_ops = {
+    .is_visible = as7816_64x_cpld_is_visible,
+};
+
+static const struct hwmon_chip_info as7816_64x_cpld_chip_info = {
+    .ops = &as7816_64x_cpld_hwmon_ops,
+    .info = as7816_64x_cpld_info,
+};
+
+static int as7816_64x_cpld_probe(struct i2c_client *client)
 {
     int status;
 	struct as7816_64x_cpld_data *data = NULL;
@@ -985,7 +1005,7 @@ static int as7816_64x_cpld_probe(struct i2c_client *client,
 	}
 
     data->hwmon_dev = hwmon_device_register_with_info(&client->dev, "as7816_64x_cpld",
-                                                      NULL, NULL, NULL);
+                                                      NULL, &as7816_64x_cpld_chip_info, NULL);
 	if (IS_ERR(data->hwmon_dev)) {
 		status = PTR_ERR(data->hwmon_dev);
 		goto exit_remove;
@@ -1007,7 +1027,7 @@ exit:
     return status;
 }
 
-static int as7816_64x_cpld_remove(struct i2c_client *client)
+static void as7816_64x_cpld_remove(struct i2c_client *client)
 {
     struct as7816_64x_cpld_data *data = i2c_get_clientdata(client);
 
@@ -1015,8 +1035,6 @@ static int as7816_64x_cpld_remove(struct i2c_client *client)
     sysfs_remove_group(&client->dev.kobj, &as7816_64x_cpld_group);
     kfree(data);
 	as7816_64x_cpld_remove_client(client);
-
-    return 0;
 }
 
 int as7816_64x_cpld_read(unsigned short cpld_addr, u8 reg)

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-fan.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-fan.c
@@ -380,8 +380,28 @@ static struct as7816_64x_fan_data *as7816_64x_fan_update_device(struct device *d
     return data;
 }
 
-static int as7816_64x_fan_probe(struct i2c_client *client,
-            const struct i2c_device_id *dev_id)
+static umode_t as7816_64x_fan_is_visible(const void *drvdata,
+                  enum hwmon_sensor_types type,
+                  u32 attr, int channel)
+{
+    return 0;
+}
+
+static const struct hwmon_channel_info *as7816_64x_fan_info[] = {
+    HWMON_CHANNEL_INFO(fan, HWMON_F_ENABLE),
+    NULL,
+};
+
+static const struct hwmon_ops as7816_64x_fan_hwmon_ops = {
+    .is_visible = as7816_64x_fan_is_visible,
+};
+
+static const struct hwmon_chip_info as7816_64x_fan_chip_info = {
+    .ops = &as7816_64x_fan_hwmon_ops,
+    .info = as7816_64x_fan_info,
+};
+
+static int as7816_64x_fan_probe(struct i2c_client *client)
 {
     struct as7816_64x_fan_data *data;
     int status;
@@ -410,7 +430,7 @@ static int as7816_64x_fan_probe(struct i2c_client *client,
     }
 
     data->hwmon_dev = hwmon_device_register_with_info(&client->dev, "as7816_64x_fan",
-                                                      NULL, NULL, NULL);
+                                                      NULL, &as7816_64x_fan_chip_info, NULL);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         goto exit_remove;
@@ -430,13 +450,11 @@ exit:
     return status;
 }
 
-static int as7816_64x_fan_remove(struct i2c_client *client)
+static void as7816_64x_fan_remove(struct i2c_client *client)
 {
     struct as7816_64x_fan_data *data = i2c_get_clientdata(client);
     hwmon_device_unregister(data->hwmon_dev);
     sysfs_remove_group(&client->dev.kobj, &as7816_64x_fan_group);
-    
-    return 0;
 }
 
 /* Addresses to scan */

--- a/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-leds.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/modules/builds/src/x86-64-accton-as7816-64x-leds.c
@@ -387,15 +387,13 @@ static int as7816_64x_led_probe(struct platform_device *pdev)
 	return ret;
 }
 
-static int as7816_64x_led_remove(struct platform_device *pdev)
+static void as7816_64x_led_remove(struct platform_device *pdev)
 {
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(as7816_64x_leds); i++) {
 		led_classdev_unregister(&as7816_64x_leds[i]);
 	}
-
-	return 0;
 }
 
 static struct platform_driver as7816_64x_led_driver = {

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/fani.c
@@ -182,6 +182,7 @@ static int
 _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 {
 	int val = 0;
+	int power_good = 0;
 	psu_type_t psu_type;
 
 	info->status |= ONLP_FAN_STATUS_PRESENT;
@@ -190,8 +191,14 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
      */
     info->status |= _onlp_get_fan_direction_on_psu();
 
+    /* If the PSU lost AC input, the fan tach is unreadable; mark FAILED
+     * rather than letting the PMBus reads fail downstream. */
+    if (onlp_file_read_int(&power_good, PSU_POWERGOOD_FORMAT, pid) == 0 &&
+        power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_FAN_STATUS_FAILED;
+        return ONLP_STATUS_OK;
+    }
 
-     
     psu_type = psu_type_get(pid, NULL, 0);
     if (psu_type == PSU_TYPE_UNKNOWN)
         return ONLP_FAN_STATUS_FAILED;

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/platform_lib.h
@@ -44,6 +44,8 @@
 
 #define PSU_PRESENT_FORMAT		"/sys/bus/i2c/devices/19-0060/psu%d_present"
 #define PSU_POWERGOOD_FORMAT	"/sys/bus/i2c/devices/19-0060/psu%d_power_good"
+#define PSU_STATUS_PRESENT      1
+#define PSU_STATUS_POWER_GOOD   1
 
 #define FAN_BOARD_PATH	"/sys/bus/i2c/devices/17-0068/"
 #define FAN_NODE(node)	FAN_BOARD_PATH#node

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/psui.c
@@ -27,9 +27,6 @@
 #include <onlplib/file.h>
 #include "platform_lib.h"
 
-#define PSU_STATUS_PRESENT     1
-#define PSU_STATUS_POWER_GOOD  1
-
 #define VALIDATE(_id)                           \
     do {                                        \
         if(!ONLP_OID_IS_PSU(_id)) {             \
@@ -48,10 +45,6 @@ psu_ym2651y_info_get(onlp_psu_info_t* info)
 {
     int val   = 0;
     int index = ONLP_OID_ID_GET(info->hdr.id);
-
-	if (info->status & ONLP_PSU_STATUS_FAILED) {
-	    return ONLP_STATUS_OK;
-	}
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
@@ -122,10 +115,7 @@ psu_dps850_info_get(onlp_psu_info_t* info)
     
     /* Set capability
      */
-    info->caps = ONLP_PSU_CAPS_AC;   
-	if (info->status & ONLP_PSU_STATUS_FAILED) {
-	    return ONLP_STATUS_OK;
-	}
+    info->caps = ONLP_PSU_CAPS_AC;
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
@@ -186,9 +176,10 @@ int
 onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 {
     int val   = 0;
+    int power_good = 0;
     int ret   = ONLP_STATUS_OK;
     int index = ONLP_OID_ID_GET(id);
-    psu_type_t psu_type; 
+    psu_type_t psu_type;
 
     VALIDATE(id);
 
@@ -208,12 +199,12 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 
 
     /* Get power good status */
-    if (onlp_file_read_int(&val, PSU_POWERGOOD_FORMAT, index) < 0) {
+    if (onlp_file_read_int(&power_good, PSU_POWERGOOD_FORMAT, index) < 0) {
         AIM_LOG_ERROR("Unable to read power status from PSU(%d)\r\n", index);
         return ONLP_STATUS_E_INTERNAL;
     }
 
-    if (val != PSU_STATUS_POWER_GOOD) {
+    if (power_good != PSU_STATUS_POWER_GOOD) {
         info->status |=  ONLP_PSU_STATUS_FAILED;
     }
 
@@ -237,6 +228,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
             ret = psu_ym2651y_info_get(info);
             break;
         case PSU_TYPE_UNKNOWN:  /* User insert a unknown PSU or unplugged.*/
+            /* Link the child fan/thermal coids so onlpdump still
+             * surfaces them under the PSU. */
+            info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
+            info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
             info->status |= ONLP_PSU_STATUS_UNPLUGGED;
             info->status &= ~ONLP_PSU_STATUS_FAILED;
             ret = ONLP_STATUS_OK;
@@ -244,6 +239,14 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         default:
             ret = ONLP_STATUS_E_UNSUPPORTED;
             break;
+    }
+
+    /* No AC input on a present PSU: surface as UNPLUGGED with no readings,
+     * but keep the fan/thermal coids set above so children stay linked. */
+    if (power_good != PSU_STATUS_POWER_GOOD) {
+        info->status |= ONLP_PSU_STATUS_UNPLUGGED;
+        info->status &= ~ONLP_PSU_STATUS_FAILED;
+        info->caps = 0;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/thermali.c
@@ -202,6 +202,12 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 		return onlp_file_read_int_max(&info->mcelsius, cpu_coretemp_files);
 	} else if(tid == THERMAL_1_ON_PSU1 || tid == THERMAL_1_ON_PSU2){
 		int pid = tid - THERMAL_1_ON_PSU1 + 1;
+		int power_good = 0;
+		if (onlp_file_read_int(&power_good, PSU_POWERGOOD_FORMAT, pid) == 0 &&
+		    power_good != PSU_STATUS_POWER_GOOD) {
+			info->status |= ONLP_THERMAL_STATUS_FAILED;
+			return ONLP_STATUS_OK;
+		}
 		return onlp_file_read_int(&info->mcelsius, "%s%s", psu_pmbus_path(pid), "psu_temp1_input");
 	}
 

--- a/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/lib/x86-64-accton-as7816-64x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/lib/x86-64-accton-as7816-64x-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-as7816-64x-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-4-14
+      <<: *kernel-6-12
 
     args: >-
       nopat

--- a/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/python/x86_64_accton_as7816_64x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/python/x86_64_accton_as7816_64x_r0/__init__.py
@@ -192,5 +192,7 @@ class OnlPlatform_x86_64_accton_as7816_64x_r0(OnlPlatformAccton,
         subprocess.call('echo port50 > /sys/bus/i2c/devices/86-0050/port_name', shell=True)
         subprocess.call('echo port51 > /sys/bus/i2c/devices/87-0050/port_name', shell=True)
         subprocess.call('echo port52 > /sys/bus/i2c/devices/88-0050/port_name', shell=True)
-        
+
+        subprocess.call('echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state > /dev/null', shell=True)
+
         return True

--- a/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/python/x86_64_accton_as7816_64x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/python/x86_64_accton_as7816_64x_r0/__init__.py
@@ -58,141 +58,28 @@ class OnlPlatform_x86_64_accton_as7816_64x_r0(OnlPlatformAccton,
                 ('pca9548', 0x75, 2),
                 ('pca9548', 0x76, 2),
 
-                # initialize QSFP port 1-64
-                ('optoe1', 0x50, 25),
-                ('optoe1', 0x50, 26),
-                ('optoe1', 0x50, 27),
-                ('optoe1', 0x50, 28),
-                ('optoe1', 0x50, 29),
-                ('optoe1', 0x50, 30),
-                ('optoe1', 0x50, 31),
-                ('optoe1', 0x50, 32),
-                ('optoe1', 0x50, 33),
-                ('optoe1', 0x50, 34),
-                ('optoe1', 0x50, 35),
-                ('optoe1', 0x50, 36),
-                ('optoe1', 0x50, 37),
-                ('optoe1', 0x50, 38),
-                ('optoe1', 0x50, 39),
-                ('optoe1', 0x50, 40),
-                ('optoe1', 0x50, 41),
-                ('optoe1', 0x50, 42),
-                ('optoe1', 0x50, 43),
-                ('optoe1', 0x50, 44),
-                ('optoe1', 0x50, 45),
-                ('optoe1', 0x50, 46),
-                ('optoe1', 0x50, 47),
-                ('optoe1', 0x50, 48),
-                ('optoe1', 0x50, 49),
-                ('optoe1', 0x50, 50),
-                ('optoe1', 0x50, 51),
-                ('optoe1', 0x50, 52),
-                ('optoe1', 0x50, 53),
-                ('optoe1', 0x50, 54),
-                ('optoe1', 0x50, 55),
-                ('optoe1', 0x50, 56),
-                ('optoe1', 0x50, 57),
-                ('optoe1', 0x50, 58),
-                ('optoe1', 0x50, 59),
-                ('optoe1', 0x50, 60),
-                ('optoe1', 0x50, 61),
-                ('optoe1', 0x50, 62),
-                ('optoe1', 0x50, 63),
-                ('optoe1', 0x50, 64),
-                ('optoe1', 0x50, 65),
-                ('optoe1', 0x50, 66),
-                ('optoe1', 0x50, 67),
-                ('optoe1', 0x50, 68),
-                ('optoe1', 0x50, 69),
-                ('optoe1', 0x50, 70),
-                ('optoe1', 0x50, 71),
-                ('optoe1', 0x50, 72),
-                ('optoe1', 0x50, 73),
-                ('optoe1', 0x50, 74),
-                ('optoe1', 0x50, 75),
-                ('optoe1', 0x50, 76),
-                ('optoe1', 0x50, 77),
-                ('optoe1', 0x50, 78),
-                ('optoe1', 0x50, 79),
-                ('optoe1', 0x50, 80),
-                ('optoe1', 0x50, 81),
-                ('optoe1', 0x50, 82),
-                ('optoe1', 0x50, 83),
-                ('optoe1', 0x50, 84),
-                ('optoe1', 0x50, 85),
-                ('optoe1', 0x50, 86),
-                ('optoe1', 0x50, 87),
-                ('optoe1', 0x50, 88),
-
                 #('24c02', 0x56, 0),
                 ])
 
-        subprocess.call('echo port61 > /sys/bus/i2c/devices/25-0050/port_name', shell=True)
-        subprocess.call('echo port62 > /sys/bus/i2c/devices/26-0050/port_name', shell=True)
-        subprocess.call('echo port63 > /sys/bus/i2c/devices/27-0050/port_name', shell=True)
-        subprocess.call('echo port64 > /sys/bus/i2c/devices/28-0050/port_name', shell=True)
-        subprocess.call('echo port55 > /sys/bus/i2c/devices/29-0050/port_name', shell=True)
-        subprocess.call('echo port56 > /sys/bus/i2c/devices/30-0050/port_name', shell=True)
-        subprocess.call('echo port53 > /sys/bus/i2c/devices/31-0050/port_name', shell=True)
-        subprocess.call('echo port54 > /sys/bus/i2c/devices/32-0050/port_name', shell=True)
-        subprocess.call('echo port9  > /sys/bus/i2c/devices/33-0050/port_name', shell=True)
-        subprocess.call('echo port10 > /sys/bus/i2c/devices/34-0050/port_name', shell=True)
-        subprocess.call('echo port11 > /sys/bus/i2c/devices/35-0050/port_name', shell=True)
-        subprocess.call('echo port12 > /sys/bus/i2c/devices/36-0050/port_name', shell=True)
-        subprocess.call('echo port1  > /sys/bus/i2c/devices/37-0050/port_name', shell=True)
-        subprocess.call('echo port2  > /sys/bus/i2c/devices/38-0050/port_name', shell=True)
-        subprocess.call('echo port3  > /sys/bus/i2c/devices/39-0050/port_name', shell=True)
-        subprocess.call('echo port4  > /sys/bus/i2c/devices/40-0050/port_name', shell=True)
-        subprocess.call('echo port6  > /sys/bus/i2c/devices/41-0050/port_name', shell=True)
-        subprocess.call('echo port5  > /sys/bus/i2c/devices/42-0050/port_name', shell=True)
-        subprocess.call('echo port8  > /sys/bus/i2c/devices/43-0050/port_name', shell=True)
-        subprocess.call('echo port7  > /sys/bus/i2c/devices/44-0050/port_name', shell=True)
-        subprocess.call('echo port13 > /sys/bus/i2c/devices/45-0050/port_name', shell=True)
-        subprocess.call('echo port14 > /sys/bus/i2c/devices/46-0050/port_name', shell=True)
-        subprocess.call('echo port15 > /sys/bus/i2c/devices/47-0050/port_name', shell=True)
-        subprocess.call('echo port16 > /sys/bus/i2c/devices/48-0050/port_name', shell=True)
-        subprocess.call('echo port17 > /sys/bus/i2c/devices/49-0050/port_name', shell=True)
-        subprocess.call('echo port18 > /sys/bus/i2c/devices/50-0050/port_name', shell=True)
-        subprocess.call('echo port19 > /sys/bus/i2c/devices/51-0050/port_name', shell=True)
-        subprocess.call('echo port20 > /sys/bus/i2c/devices/52-0050/port_name', shell=True)
-        subprocess.call('echo port25 > /sys/bus/i2c/devices/53-0050/port_name', shell=True)
-        subprocess.call('echo port26 > /sys/bus/i2c/devices/54-0050/port_name', shell=True)
-        subprocess.call('echo port27 > /sys/bus/i2c/devices/55-0050/port_name', shell=True)
-        subprocess.call('echo port28 > /sys/bus/i2c/devices/56-0050/port_name', shell=True)
-
-        subprocess.call('echo port29 > /sys/bus/i2c/devices/57-0050/port_name', shell=True)
-        subprocess.call('echo port30 > /sys/bus/i2c/devices/58-0050/port_name', shell=True)
-        subprocess.call('echo port31 > /sys/bus/i2c/devices/59-0050/port_name', shell=True)
-        subprocess.call('echo port32 > /sys/bus/i2c/devices/60-0050/port_name', shell=True)
-        subprocess.call('echo port21 > /sys/bus/i2c/devices/61-0050/port_name', shell=True)
-        subprocess.call('echo port22 > /sys/bus/i2c/devices/62-0050/port_name', shell=True)
-        subprocess.call('echo port23 > /sys/bus/i2c/devices/63-0050/port_name', shell=True)
-        subprocess.call('echo port24 > /sys/bus/i2c/devices/64-0050/port_name', shell=True)
-        subprocess.call('echo port41 > /sys/bus/i2c/devices/65-0050/port_name', shell=True)
-        subprocess.call('echo port42 > /sys/bus/i2c/devices/66-0050/port_name', shell=True)
-        subprocess.call('echo port43 > /sys/bus/i2c/devices/67-0050/port_name', shell=True)
-        subprocess.call('echo port44 > /sys/bus/i2c/devices/68-0050/port_name', shell=True)
-        subprocess.call('echo port33 > /sys/bus/i2c/devices/69-0050/port_name', shell=True)
-        subprocess.call('echo port34 > /sys/bus/i2c/devices/70-0050/port_name', shell=True)
-        subprocess.call('echo port35 > /sys/bus/i2c/devices/71-0050/port_name', shell=True)
-        subprocess.call('echo port36 > /sys/bus/i2c/devices/72-0050/port_name', shell=True)
-        subprocess.call('echo port45 > /sys/bus/i2c/devices/73-0050/port_name', shell=True)
-        subprocess.call('echo port46 > /sys/bus/i2c/devices/74-0050/port_name', shell=True)
-        subprocess.call('echo port47 > /sys/bus/i2c/devices/75-0050/port_name', shell=True)
-        subprocess.call('echo port48 > /sys/bus/i2c/devices/76-0050/port_name', shell=True)
-        subprocess.call('echo port37 > /sys/bus/i2c/devices/77-0050/port_name', shell=True)
-        subprocess.call('echo port38 > /sys/bus/i2c/devices/78-0050/port_name', shell=True)
-        subprocess.call('echo port39 > /sys/bus/i2c/devices/79-0050/port_name', shell=True)
-        subprocess.call('echo port40 > /sys/bus/i2c/devices/80-0050/port_name', shell=True)
-        subprocess.call('echo port57 > /sys/bus/i2c/devices/81-0050/port_name', shell=True)
-        subprocess.call('echo port58 > /sys/bus/i2c/devices/82-0050/port_name', shell=True)
-        subprocess.call('echo port59 > /sys/bus/i2c/devices/83-0050/port_name', shell=True)
-        subprocess.call('echo port60 > /sys/bus/i2c/devices/84-0050/port_name', shell=True)
-        subprocess.call('echo port49 > /sys/bus/i2c/devices/85-0050/port_name', shell=True)
-        subprocess.call('echo port50 > /sys/bus/i2c/devices/86-0050/port_name', shell=True)
-        subprocess.call('echo port51 > /sys/bus/i2c/devices/87-0050/port_name', shell=True)
-        subprocess.call('echo port52 > /sys/bus/i2c/devices/88-0050/port_name', shell=True)
-
         subprocess.call('echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state > /dev/null', shell=True)
+
+        # Front-panel port -> mux-leaf i2c bus. Indexed by (port - 1).
+        # The pca9548 leaf channels are not wired in port order, so the
+        # mapping is irregular (note the 5<->6, 7<->8 pair swaps, and the
+        # 4-port blocks that are out of sequence across the tree).
+        port_i2c_bus = [
+            37, 38, 39, 40, 42, 41, 44, 43,  # port  1-8
+            33, 34, 35, 36, 45, 46, 47, 48,  # port  9-16
+            49, 50, 51, 52, 61, 62, 63, 64,  # port 17-24
+            53, 54, 55, 56, 57, 58, 59, 60,  # port 25-32
+            69, 70, 71, 72, 77, 78, 79, 80,  # port 33-40
+            65, 66, 67, 68, 73, 74, 75, 76,  # port 41-48
+            85, 86, 87, 88, 31, 32, 29, 30,  # port 49-56
+            81, 82, 83, 84, 25, 26, 27, 28,  # port 57-64
+        ]
+        for port in range(1, 65):
+            bus = port_i2c_bus[port - 1]
+            self.new_i2c_device('optoe1', 0x50, bus)
+            subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, bus), shell=True)
 
         return True


### PR DESCRIPTION
## Summary

Upgrades AS7816-64X from kernel 4.14 to 6.12 LTS.

### Config
- `modules/PKG.yml`, `modules/builds/Makefile`: `KERNELS` switched to `onl-kernel-6.12-lts-x86-64-all`
- `platform-config/r0/.../x86-64-accton-as7816-64x-r0.yml`: kernel anchor `*kernel-4-14` → `*kernel-6-12`
- `platform-config/r0/.../__init__.py`: set `idle_state=-2` (`MUX_IDLE_AS_IS`) on every `pca9548` after instantiation so each mux holds its last channel selection and a transient on the iSMT shared lines cannot quietly re-route an access to the wrong leaf

### Build layout
- Moved `cpld1/fan/leds.c` from `modules/builds/` into `modules/builds/src/` with an explicit Kbuild (`obj-m += ...`). Newer kbuild builds each top-level `.c` as its own standalone module, so `leds.c`'s references to `as7816_64x_cpld_read/write` failed `modpost` even though `cpld1.c` exports them. The src/ subdir mirrors the convention already used by other 6.12-ready platforms.
- Inlined `accton_i2c_cpld.c` into this platform's `src/`. The shared `packages/platforms/accton/x86-64/modules/` package still targets 4.14 only, so on 6.12 there is no `accton_i2c_cpld.ko` for `baseconfig()` to `insmod`. Inlining keeps the upgrade scoped to this platform without forcing a kernel-version bump on platforms still on 4.14.

### Driver API (4.14 → 6.12)
- `cpld1.c`:
  - `i2c_driver.probe()` single-arg signature (`dev_id` not consumed)
  - `i2c_driver.remove()` returns `void`
  - `hwmon_device_register_with_info()` now requires a non-NULL `chip_info`; added a minimal stub (`hwmon_ops { is_visible → 0 }` + a single `HWMON_CHANNEL_INFO(chip, ...)`) since 6.12 rejects `chip=NULL` with `-EINVAL`
- `fan.c`: same probe / remove / chip_info changes as `cpld1.c`
- `leds.c`: `platform_driver.remove()` returns `void` per 6.11+ API
- `accton_i2c_cpld.c` (inlined): single-arg `probe()`, void `remove()`

### ONLP
- No changes needed — `IDPROM_PATH` already uses the bus-style `/sys/bus/i2c/devices/0-0056/eeprom` path, `onlp_sysi_onie_data_get()` reads bus 0 via `onlp_i2c_readw()` rather than `onlp_onie_decode_file()` (no local `onlp_onie_info_t` to zero-init), and the only `aim_fstrdup()` call uses `%d` format (no NULL `%s` UB risk)